### PR TITLE
Fix sort operations on fix_position

### DIFF
--- a/projects/controllers/experiments.py
+++ b/projects/controllers/experiments.py
@@ -22,8 +22,11 @@ def list_experiments(project_id):
     Returns:
         A list of all experiments ids.
     """
-    experiments = db_session.query(Experiment).filter_by(project_id=project_id).all()
-    return sorted([experiment.as_dict() for experiment in experiments], key=lambda e: e["position"])
+    experiments = db_session.query(Experiment) \
+        .filter_by(project_id=project_id) \
+        .order_by(Experiment.position.asc()) \
+        .all()
+    return [experiment.as_dict() for experiment in experiments]
 
 
 def create_experiment(name=None, project_id=None, dataset=None, target=None,
@@ -142,7 +145,9 @@ def fix_positions(project_id, experiment_id=None, new_position=None):
     """
     other_experiments = db_session.query(Experiment) \
         .filter_by(project_id=project_id) \
-        .filter(Experiment.uuid != experiment_id).all()
+        .filter(Experiment.uuid != experiment_id)\
+        .order_by(Experiment.position.asc())\
+        .all()
 
     if experiment_id is not None:
         experiment = Experiment.query.get(experiment_id)

--- a/projects/controllers/operators.py
+++ b/projects/controllers/operators.py
@@ -21,8 +21,11 @@ def list_operators(project_id, experiment_id):
     Returns:
         A list of all operator ids.
     """
-    operators = Operator.query.filter_by(experiment_id=experiment_id)
-    return sorted([operator.as_dict() for operator in operators], key=lambda e: e["position"])
+    operators = db_session.query(Operator) \
+        .filter_by(experiment_id=experiment_id) \
+        .order_by(Operator.position.asc()) \
+        .all()
+    return [operator.as_dict() for operator in operators]
 
 
 def create_operator(project_id, experiment_id, component_id=None, **kwargs):
@@ -118,7 +121,9 @@ def fix_positions(experiment_id, operator_id=None, new_position=-1):
     """
     other_operators = db_session.query(Operator) \
         .filter_by(experiment_id=experiment_id) \
-        .filter(Operator.uuid != operator_id).all()
+        .filter(Operator.uuid != operator_id)\
+        .order_by(Operator.position.asc()) \
+        .all()
 
     if operator_id is not None:
         operator = Operator.query.get(operator_id)


### PR DESCRIPTION
It was relying on the order returned by the query. Now, 'order by'
clause enforces to keep the previous positions.