### PR TITLE
Avoids duplicates components when --sample-config is set

### DIFF
--- a/projects/samples.py
+++ b/projects/samples.py
@@ -1,19 +1,24 @@
 # -*- coding: utf-8 -*-
 from json import load
 
-from .controllers.components import create_component
+from .controllers.components import create_component, list_components
 
 
 def init_components(config_path):
-    """Installs the components from a config file.
+    """Installs the components from a config file. Avoids duplicates.
 
     Args:
         config_path (str): the path to the config file.
     """
     with open(config_path) as f:
         components = load(f)
+        existing = [c["name"] for c in list_components() if c["isDefault"]]
         for component in components:
             name = component["name"]
+            # if this component already exists,
+            # skip this and avoid creating a duplicate
+            if name in existing:
+                continue
             description = component["description"]
             tags = component["tags"]
             training_notebook = read_notebook(component["trainingNotebook"])


### PR DESCRIPTION
If an existing component is_default = 1, and names are equal,
do not create the component from --sample-config.