### PR TITLE
Allows saving parameters values in an operator

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -727,6 +727,10 @@ components:
           format: uuid
         position:
           type: integer
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
         experimentId:
           type: string
           format: uuid
@@ -853,6 +857,10 @@ components:
             properties:
               componentId:
                 type: string
+              parameters:
+                type: object
+                additionalProperties:
+                  type: string
     OperatorPatch:
       content:
         application/json:
@@ -863,6 +871,10 @@ components:
                 type: string
               position:
                 type: integer
+              parameters:
+                type: object
+                additionalProperties:
+                  type: string
     TemplatePost:
       content:
         application/json:

--- a/projects/models/operators.py
+++ b/projects/models/operators.py
@@ -2,7 +2,7 @@
 """Operator model."""
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, Integer, String, ForeignKey
+from sqlalchemy import Column, DateTime, Integer, JSON, String, ForeignKey
 
 from ..database import Base
 from ..utils import to_camel_case
@@ -14,6 +14,7 @@ class Operator(Base):
     experiment_id = Column(String(255), ForeignKey("experiments.uuid"), nullable=False)
     component_id = Column(String(255), ForeignKey("components.uuid"), nullable=False)
     position = Column(Integer)
+    parameters = Column(JSON, nullable=False, default={})
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -16,6 +16,7 @@ OPERATOR_ID = str(uuid4())
 DATASET = "iris"
 TARGET = "col4"
 POSITION = 0
+PARAMETERS = {"coef": 0.1}
 DESCRIPTION = "long foo"
 TAGS = ["PREDICTOR"]
 TRAINING_NOTEBOOK_PATH = "minio://{}/components/{}/Training.ipynb".format(BUCKET_NAME, COMPONENT_ID)
@@ -24,7 +25,7 @@ CREATED_AT = "2000-01-01 00:00:00"
 CREATED_AT_ISO = "2000-01-01T00:00:00"
 UPDATED_AT = "2000-01-01 00:00:00"
 UPDATED_AT_ISO = "2000-01-01T00:00:00"
-OPERATORS = [{"uuid": OPERATOR_ID, "componentId": COMPONENT_ID, "position": POSITION, "experimentId": EXPERIMENT_ID, "createdAt": CREATED_AT_ISO, "updatedAt": UPDATED_AT_ISO}]
+OPERATORS = [{"uuid": OPERATOR_ID, "componentId": COMPONENT_ID, "position": POSITION, "parameters": PARAMETERS, "experimentId": EXPERIMENT_ID, "createdAt": CREATED_AT_ISO, "updatedAt": UPDATED_AT_ISO}]
 
 
 class TestExperiments(TestCase):
@@ -40,7 +41,7 @@ class TestExperiments(TestCase):
         text = "INSERT INTO experiments (uuid, name, project_id, dataset, target, position, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')".format(EXPERIMENT_ID, NAME, PROJECT_ID, DATASET, TARGET, POSITION, CREATED_AT, UPDATED_AT)
         conn.execute(text)
 
-        text = "INSERT INTO operators (uuid, experiment_id, component_id, position, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}')".format(OPERATOR_ID, EXPERIMENT_ID, COMPONENT_ID, POSITION, CREATED_AT, UPDATED_AT)
+        text = "INSERT INTO operators (uuid, experiment_id, component_id, position, parameters, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}')".format(OPERATOR_ID, EXPERIMENT_ID, COMPONENT_ID, POSITION, dumps(PARAMETERS), CREATED_AT, UPDATED_AT)
         conn.execute(text)
 
         text = "INSERT INTO templates (uuid, name, components, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}')".format(TEMPLATE_ID, NAME, dumps([COMPONENT_ID]), CREATED_AT, UPDATED_AT)
@@ -213,6 +214,7 @@ class TestExperiments(TestCase):
                 "componentId": COMPONENT_ID,
                 "experimentId": EXPERIMENT_ID,
                 "position": POSITION,
+                "parameters": {},
             }]
             machine_generated = ["uuid", "createdAt", "updatedAt"]
             for attr in machine_generated:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -17,6 +17,7 @@ PARAMETERS = {"coef": 0.1}
 DATASET = "iris"
 TARGET = "col4"
 POSITION = 0
+PARAMETERS = {}
 TAGS = ["PREDICTOR"]
 TRAINING_NOTEBOOK_PATH = "minio://{}/components/{}/Training.ipynb".format(BUCKET_NAME, COMPONENT_ID)
 INFERENCE_NOTEBOOK_PATH = "minio://{}/components/{}/Inference.ipynb".format(BUCKET_NAME, COMPONENT_ID)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -13,6 +13,7 @@ DESCRIPTION = "long foo"
 PROJECT_ID = str(uuid4())
 EXPERIMENT_ID = str(uuid4())
 COMPONENT_ID = str(uuid4())
+PARAMETERS = {"coef": 0.1}
 DATASET = "iris"
 TARGET = "col4"
 POSITION = 0
@@ -37,7 +38,7 @@ class TestOperators(TestCase):
         text = "INSERT INTO components (uuid, name, description, tags, training_notebook_path, inference_notebook_path, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')".format(COMPONENT_ID, NAME, DESCRIPTION, dumps(TAGS), TRAINING_NOTEBOOK_PATH, INFERENCE_NOTEBOOK_PATH, CREATED_AT, UPDATED_AT)
         conn.execute(text)
 
-        text = "INSERT INTO operators (uuid, experiment_id, component_id, position, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}')".format(OPERATOR_ID, EXPERIMENT_ID, COMPONENT_ID, POSITION, CREATED_AT, UPDATED_AT)
+        text = "INSERT INTO operators (uuid, experiment_id, component_id, position, parameters, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}')".format(OPERATOR_ID, EXPERIMENT_ID, COMPONENT_ID, POSITION, dumps(PARAMETERS), CREATED_AT, UPDATED_AT)
         conn.execute(text)
         conn.close()
 
@@ -104,12 +105,50 @@ class TestOperators(TestCase):
 
             rv = c.post("/projects/{}/experiments/{}/operators".format(PROJECT_ID, EXPERIMENT_ID), json={
                 "componentId": COMPONENT_ID,
+                "parameters": [{"name": "coef", "value": 0.1}],
+            })
+            result = rv.get_json()
+            expected = {"message": "The specified parameters are not valid"}
+            self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
+
+            rv = c.post("/projects/{}/experiments/{}/operators".format(PROJECT_ID, EXPERIMENT_ID), json={
+                "componentId": COMPONENT_ID,
+                "parameters": {"coef": [0.1]},
+            })
+            result = rv.get_json()
+            expected = {"message": "The specified parameters are not valid"}
+            self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
+
+            rv = c.post("/projects/{}/experiments/{}/operators".format(PROJECT_ID, EXPERIMENT_ID), json={
+                "componentId": COMPONENT_ID,
             })
             result = rv.get_json()
             expected = {
                 "experimentId": EXPERIMENT_ID,
                 "componentId": COMPONENT_ID,
                 "position": 1,
+                "parameters": {},
+            }
+            # uuid, created_at, updated_at are machine-generated
+            # we assert they exist, but we don't assert their values
+            machine_generated = ["uuid", "createdAt", "updatedAt"]
+            for attr in machine_generated:
+                self.assertIn(attr, result)
+                del result[attr]
+            self.assertDictEqual(expected, result)
+
+            rv = c.post("/projects/{}/experiments/{}/operators".format(PROJECT_ID, EXPERIMENT_ID), json={
+                "componentId": COMPONENT_ID,
+                "parameters": {"coef": 1.0}
+            })
+            result = rv.get_json()
+            expected = {
+                "experimentId": EXPERIMENT_ID,
+                "componentId": COMPONENT_ID,
+                "position": 2,
+                "parameters": {"coef": 1.0},
             }
             # uuid, created_at, updated_at are machine-generated
             # we assert they exist, but we don't assert their values
@@ -146,6 +185,22 @@ class TestOperators(TestCase):
             self.assertEqual(rv.status_code, 400)
 
             rv = c.patch("/projects/{}/experiments/{}/operators/{}".format(PROJECT_ID, EXPERIMENT_ID, OPERATOR_ID), json={
+                "parameters": [{"name": "coef", "value": 0.1}],
+            })
+            result = rv.get_json()
+            expected = {"message": "The specified parameters are not valid"}
+            self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
+
+            rv = c.patch("/projects/{}/experiments/{}/operators/{}".format(PROJECT_ID, EXPERIMENT_ID, OPERATOR_ID), json={
+                "parameters": {"coef": [0.1]},
+            })
+            result = rv.get_json()
+            expected = {"message": "The specified parameters are not valid"}
+            self.assertDictEqual(expected, result)
+            self.assertEqual(rv.status_code, 400)
+
+            rv = c.patch("/projects/{}/experiments/{}/operators/{}".format(PROJECT_ID, EXPERIMENT_ID, OPERATOR_ID), json={
                 "position": 0,
             })
             result = rv.get_json()
@@ -154,6 +209,25 @@ class TestOperators(TestCase):
                 "experimentId": EXPERIMENT_ID,
                 "componentId": COMPONENT_ID,
                 "position": 0,
+                "parameters": PARAMETERS,
+                "createdAt": CREATED_AT_ISO,
+            }
+            machine_generated = ["updatedAt"]
+            for attr in machine_generated:
+                self.assertIn(attr, result)
+                del result[attr]
+            self.assertDictEqual(expected, result)
+
+            rv = c.patch("/projects/{}/experiments/{}/operators/{}".format(PROJECT_ID, EXPERIMENT_ID, OPERATOR_ID), json={
+                "parameters": {"coef": 0.2},
+            })
+            result = rv.get_json()
+            expected = {
+                "uuid": OPERATOR_ID,
+                "experimentId": EXPERIMENT_ID,
+                "componentId": COMPONENT_ID,
+                "position": 0,
+                "parameters": {"coef": 0.2},
                 "createdAt": CREATED_AT_ISO,
             }
             machine_generated = ["updatedAt"]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -16,6 +16,7 @@ OPERATOR_ID = str(uuid4())
 DATASET = "iris"
 TARGET = "col4"
 POSITION = 0
+PARAMETERS = {"coef": 0.1}
 OPERATORS = [{"componentId": COMPONENT_ID, "position": POSITION}]
 DESCRIPTION = "long foo"
 TAGS = ["PREDICTOR"]
@@ -29,6 +30,7 @@ UPDATED_AT_ISO = "2000-01-01T00:00:00"
 
 class TestTemplates(TestCase):
     def setUp(self):
+        self.maxDiff = None
         conn = engine.connect()
         text = "INSERT INTO components (uuid, name, description, tags, training_notebook_path, inference_notebook_path, is_default, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')".format(COMPONENT_ID, NAME, DESCRIPTION, dumps(TAGS), TRAINING_NOTEBOOK_PATH, INFERENCE_NOTEBOOK_PATH, 0, CREATED_AT, UPDATED_AT)
         conn.execute(text)
@@ -39,7 +41,7 @@ class TestTemplates(TestCase):
         text = "INSERT INTO experiments (uuid, name, project_id, dataset, target, position, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}')".format(EXPERIMENT_ID, NAME, PROJECT_ID, DATASET, TARGET, POSITION, CREATED_AT, UPDATED_AT)
         conn.execute(text)
 
-        text = "INSERT INTO operators (uuid, experiment_id, component_id, position, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}')".format(OPERATOR_ID, EXPERIMENT_ID, COMPONENT_ID, POSITION, CREATED_AT, UPDATED_AT)
+        text = "INSERT INTO operators (uuid, experiment_id, component_id, position, parameters, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}', '{}', '{}')".format(OPERATOR_ID, EXPERIMENT_ID, COMPONENT_ID, POSITION, dumps(PARAMETERS), CREATED_AT, UPDATED_AT)
         conn.execute(text)
 
         text = "INSERT INTO templates (uuid, name, components, created_at, updated_at) VALUES ('{}', '{}', '{}', '{}', '{}')".format(TEMPLATE_ID, NAME, dumps([COMPONENT_ID]), CREATED_AT, UPDATED_AT)


### PR DESCRIPTION
- Adds a new column 'parameters', type JSON to table 'operators'
- Validates if parameters is a dictionary
(object str->[str|int|float])
- Adds unit tests
- Updates docs