### PR TITLE
Refactoring component notebooks

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -667,6 +667,8 @@ components:
           format: uuid
         name:
           type: string
+        description:
+          type: string
         experiments:
           type: array
           items:
@@ -821,6 +823,8 @@ components:
             type: object
             properties:
               name:
+                type: string
+              description:
                 type: string
     ExperimentPost:
       content:

--- a/projects/config/Inference.ipynb
+++ b/projects/config/Inference.ipynb
@@ -33,13 +33,12 @@
     "    Visit https://platiagro.github.io/sdk/ to find all the details about the SDK.\n",
     "    \"\"\"\n",
     "\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Loads models and other artifacts using PlatIAgro SDK\n",
-    "        model = load_model(name=experiment_id)\n",
+    "        model = load_model()\n",
     "\n",
     "        self.columns_names = [\"col0\", \"col1\", \"col2\", \"col3\"]\n",
     "\n",
@@ -71,9 +70,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
+    "There are two sections:\n",
+    "\n",
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
    ]
   },
   {
@@ -82,78 +94,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"a71b85d0-6d92-4868-80a1-d2efd270ca5f\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
-    "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
+    "## Test Deployment\n",
     "\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    },\n",
-    "    \"meta\": {}\n",
-    "}\n",
-    "EOF"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -162,34 +160,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cat log.txt"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-microservice | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "a71b85d0-6d92-4868-80a1-d2efd270ca5f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -205,8 +183,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "c0deb81a-540e-4d51-bf8f-c332f9b9fd73"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/projects/config/Training.ipynb
+++ b/projects/config/Training.ipynb
@@ -17,8 +17,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -36,9 +34,7 @@
    "outputs": [],
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
-    "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"a71b85d0-6d92-4868-80a1-d2efd270ca5f\" #@param {type:\"string\"}\n",
-    "operator_id = \"c0deb81a-540e-4d51-bf8f-c332f9b9fd73\" #@param {type:\"string\"}"
+    "target = \"Species\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -87,6 +83,7 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "a71b85d0-6d92-4868-80a1-d2efd270ca5f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -102,8 +99,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "c0deb81a-540e-4d51-bf8f-c332f9b9fd73"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/projects/controllers/projects.py
+++ b/projects/controllers/projects.py
@@ -35,7 +35,7 @@ def create_project(name=None, **kwargs):
     if not isinstance(name, str):
         raise BadRequest("name is required")
 
-    project = Project(uuid=str(uuid4()), name=name)
+    project = Project(uuid=str(uuid4()), name=name, description=kwargs.get("description"))
     db_session.add(project)
     db_session.commit()
     create_experiment(name="Novo experimento", project_id=project.uuid)

--- a/projects/models/project.py
+++ b/projects/models/project.py
@@ -15,6 +15,7 @@ class Project(Base):
     name = Column(Text, nullable=False)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    description = Column(Text)
     experiments = relationship("Experiment", lazy="joined")
 
     def __repr__(self):

--- a/projects/object_storage.py
+++ b/projects/object_storage.py
@@ -16,6 +16,7 @@ MINIO_CLIENT = Minio(
 )
 
 
+
 def make_bucket(name):
     """Creates the bucket in MinIO. Ignores exception if bucket already exists.
 

--- a/samples/automl-classifier/Inference.ipynb
+++ b/samples/automl-classifier/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -28,32 +39,22 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from platiagro import load_model\n",
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL, infer_featuretypes\n",
-    "from sklearn.exceptions import NotFittedError \n",
-    "from sklearn.utils.validation import check_is_fitted\n",
     "\n",
     "logger = logging.getLogger(__name__)\n",
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None, method: str = \"predict_proba\"):\n",
+    "    def __init__(self, dataset: str = None, target: str = None, method: str = \"predict_proba\"):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
-    "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "        logger.info(f\"method: {method}\")\n",
     "\n",
     "        self.method = method\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
-    "        self.label_encoder = model[\"label_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        self.label_encoder = model[\"label_encoder\"]\n",
     "\n",
     "    def class_names(self):\n",
     "        if self.method == \"predict_proba\":\n",
@@ -72,26 +73,14 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
     "        if self.method == \"predict_proba\":\n",
-    "            y_pred = self.estimator.predict_proba(X)\n",
+    "            y_pred = self.pipeline.predict_proba(X)\n",
     "        else:\n",
-    "            y_pred = self.estimator.predict(X)\n",
+    "            y_pred = self.pipeline.predict(X)\n",
     "            y_pred = self.label_encoder.inverse_transform(y_pred)\n",
     "\n",
     "        return y_pred"
@@ -101,61 +90,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"48f2668a-e31a-4b5a-a91a-28fd649f7adc\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -164,60 +180,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Cleans up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "48f2668a-e31a-4b5a-a91a-28fd649f7adc",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -233,9 +203,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "64401802-2785-4f26-85c8-d7974fc78454"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/automl-classifier/Training.ipynb
+++ b/samples/automl-classifier/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -43,8 +41,6 @@
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
     "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"48f2668a-e31a-4b5a-a91a-28fd649f7adc\" #@param {type:\"string\"}\n",
-    "operator_id = \"64401802-2785-4f26-85c8-d7974fc78454\" #@param {type:\"string\"}\n",
     "duration = 60 #@param {type:\"integer\", label:\"Limite de tempo (em segundos)\"}"
    ]
   },
@@ -86,114 +82,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -252,14 +149,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sklearn.compose import ColumnTransformer\n",
     "from autosklearn.classification import AutoSklearnClassifier\n",
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.feature_selection import VarianceThreshold\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = AutoSklearnClassifier(\n",
-    "    time_left_for_this_task=duration,\n",
-    "    per_run_time_limit=duration,\n",
-    ")\n",
-    "estimator.fit(X_train, y_train, feat_type=featuretypes)\n",
-    "estimator.refit(X_train, y_train)"
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle missing values', ColumnTransformer(\n",
+    "    [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "     ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "    remainder='drop')),\n",
+    "    ('handle categorical features', ColumnTransformer(\n",
+    "    [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "    remainder='passthrough')),\n",
+    "    ('variance threshold', VarianceThreshold(threshold=0)),\n",
+    "    ('estimator', AutoSklearnClassifier(time_left_for_this_task=duration, per_run_time_limit=duration)),\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train)\n",
+    "pipeline.named_steps.estimator.refit(X_train, y_train)"
    ]
   },
   {
@@ -282,7 +195,7 @@
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes confusion matrix\n",
     "labels = np.unique(y)\n",
@@ -311,7 +224,7 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, confusion_matrix=confusion_matrix)"
+    "save_metrics(confusion_matrix=confusion_matrix)"
    ]
   },
   {
@@ -332,20 +245,15 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"label_encoder\": label_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline,\n",
+    "           label_encoder=label_encoder,\n",
+    "           columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "48f2668a-e31a-4b5a-a91a-28fd649f7adc",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -361,8 +269,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "64401802-2785-4f26-85c8-d7974fc78454"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/automl-regressor/Inference.ipynb
+++ b/samples/automl-regressor/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,20 +44,17 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        \n",
+    "    def class_names(self):\n",
+    "        return [\"estimate\"]\n",
     "\n",
     "    def predict(self, X: np.ndarray, feature_names: Iterable[str], meta: Dict = None) -> Union[np.ndarray, List, str, bytes]:\n",
     "        \"\"\"Takes an array (numpy) X and feature_names and returns an array of predictions.\n",
@@ -59,84 +67,141 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
-    "        return self.estimator.predict(X)"
+    "        return self.pipeline.predict(X)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"boston\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"medv\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"6db0fff7-ba9d-4f64-8cbe-9a31bd8b3644\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"crim\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"zn\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"indus\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"chas\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"nox\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 10.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"age\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"dis\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rad\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [1.0, 24.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"tax\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"ptratio\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"black\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"lstat\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"estimate\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -145,60 +210,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"crim\", \"zn\", \"indus\", \"chas\", \"nox\", \"rm\", \"age\", \"dis\", \"rad\", \"tax\", \"ptratio\", \"black\", \"lstat\"],\n",
-    "        \"ndarray\": [\n",
-    "            [0.00632, 18.0, 2.31, 0, 0.5379999999999999, 6.575, 65.2, 4.09, 1, 296, 15.3, 396.9, 4.98]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Cleans up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "6db0fff7-ba9d-4f64-8cbe-9a31bd8b3644",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -214,9 +233,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "1fbe7220-0b4b-4eb6-aba2-b8afec49250d"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/automl-regressor/Training.ipynb
+++ b/samples/automl-regressor/Training.ipynb
@@ -23,9 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
-    "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
     "You may also declare custom parameters to set when running an experiment."
@@ -43,8 +40,6 @@
    "source": [
     "dataset = \"boston\" #@param {type:\"string\"}\n",
     "target = \"medv\" #@param {type:\"string\"}\n",
-    "experiment_id = \"6db0fff7-ba9d-4f64-8cbe-9a31bd8b3644\" #@param {type:\"string\"}\n",
-    "operator_id = \"1fbe7220-0b4b-4eb6-aba2-b8afec49250d\" #@param {type:\"string\"}\n",
     "duration = 60 #@param {type:\"integer\", label:\"Limite de tempo (em segundos)\"}"
    ]
   },
@@ -86,114 +81,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -231,14 +127,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.feature_selection import VarianceThreshold\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from autosklearn.regression import AutoSklearnRegressor\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = AutoSklearnRegressor(\n",
-    "    time_left_for_this_task=duration,\n",
-    "    per_run_time_limit=duration,\n",
-    ")\n",
-    "estimator.fit(X_train, y_train, feat_type=featuretypes)\n",
-    "estimator.refit(X_train, y_train)"
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle missing values', ColumnTransformer(\n",
+    "    [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "     ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "    remainder='drop')),\n",
+    "    ('handle categorical features', ColumnTransformer(\n",
+    "    [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "    remainder='passthrough')),\n",
+    "    ('variance threshold', VarianceThreshold(threshold=0)),\n",
+    "    ('estimator', AutoSklearnRegressor(time_left_for_this_task=duration, per_run_time_limit=duration)),\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train)\n",
+    "pipeline.named_steps.estimator.refit(X_train, y_train)"
    ]
   },
   {
@@ -259,7 +172,7 @@
     "from sklearn.metrics import r2_score\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes R²\n",
     "r2 = r2_score(y_test, y_pred)"
@@ -283,7 +196,7 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, r2_score=r2)"
+    "save_metrics(r2_score=r2)"
    ]
   },
   {
@@ -385,7 +298,7 @@
     "plt.grid(True)\n",
     "plt.title(\"Error Distribution\")\n",
     "\n",
-    "save_figure(experiment_id=experiment_id, operator_id=operator_id, figure=plt.gcf())"
+    "save_figure(figure=plt.gcf())"
    ]
   },
   {
@@ -406,19 +319,13 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline, columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "6db0fff7-ba9d-4f64-8cbe-9a31bd8b3644",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -434,8 +341,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "1fbe7220-0b4b-4eb6-aba2-b8afec49250d"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/imputer/Inference.ipynb
+++ b/samples/imputer/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,20 +44,19 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
     "        self.strategy = model[\"strategy\"]\n",
     "        self.numerical_indexes = model[\"numerical_indexes\"]\n",
     "\n",
     "    def class_names(self):\n",
-    "        return self.columns[~pd.isna(self.estimator.statistics_)].tolist()\n",
+    "        return self.columns.tolist()\n",
     "\n",
     "    def predict(self, X: np.ndarray, feature_names: Iterable[str], meta: Dict = None) -> Union[np.ndarray, List, str, bytes]:\n",
     "        \"\"\"Takes an array (numpy) X and feature_names and completes missing values.\n",
@@ -59,17 +69,14 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace None with np.nan\n",
-    "        df.fillna(value=pd.np.nan, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
     "        # Perform Transformation\n",
     "        if self.strategy == \"mean\" or self.strategy == \"median\":\n",
-    "            X[:, self.numerical_indexes] = self.estimator.transform(X[:, self.numerical_indexes])\n",
+    "            X[:, self.numerical_indexes] = self.pipeline.transform(X)\n",
     "        elif self.strategy == \"most_frequent\":\n",
-    "            X = self.estimator.transform(X)\n",
+    "            X = self.pipeline.transform(X)\n",
     "        return X"
    ]
   },
@@ -77,61 +84,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"b48b03b1-5581-4e1d-a429-f31a34f78e1c\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make transformations"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -140,60 +174,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-microservice | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "94c3e6b9-0420-4d48-a5df-2d31fc2ad3af",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -209,9 +197,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "a43611a0-3d85-4bee-b94a-4ab7b01e9e21"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/imputer/Training.ipynb
+++ b/samples/imputer/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -43,9 +41,7 @@
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
     "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"b48b03b1-5581-4e1d-a429-f31a34f78e1c\" #@param {type:\"string\"}\n",
-    "operator_id = \"76f521c2-ff17-4850-944d-09188eeb27c1\" #@param {type:\"string\"}\n",
-    "strategy = \"most_frequent\" #@param {type:\"string\", label:\"Estratégia de atribuição de valores\", description:\"mean - apenas para atributos numéricos<br>median - apenas para atributos numéricos<br>most_frequent - em atributos numéricos e categóricos\"}"
+    "strategy = \"mean\" #@param {type:\"string\", label:\"Estratégia de atribuição de valores\", description:\"mean - apenas para atributos numéricos<br>median - apenas para atributos numéricos<br>most_frequent - em atributos numéricos e categóricos\"}"
    ]
   },
   {
@@ -71,19 +67,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "columns = df.columns.to_numpy()\n",
-    "target_index = np.argwhere(columns == target)\n",
-    "columns = np.delete(columns, target_index)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -97,16 +80,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
+    "columns = df.columns.to_numpy()\n",
     "featuretypes = np.array(featuretypes)\n",
+    "target_index = np.argwhere(columns == target)\n",
+    "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
    ]
   },
@@ -123,30 +106,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import pandas as pd\n",
     "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
     "from sklearn.impute import SimpleImputer\n",
-    "\n",
-    "# Replace None with np.nan\n",
-    "df.fillna(value=pd.np.nan, inplace=True)\n",
-    "\n",
-    "# Put data back in a numpy.ndarray\n",
-    "X = df.drop(target, axis=1).to_numpy()\n",
+    "from sklearn.pipeline import Pipeline\n",
     "\n",
     "numerical_indexes = (featuretypes == NUMERICAL)\n",
     "\n",
-    "estimator = SimpleImputer(missing_values=np.nan, strategy=strategy)\n",
+    "if strategy in [\"mean\", \"median\"]:\n",
+    "    pipeline = Pipeline(steps=[\n",
+    "    ('handler',\n",
+    "        ColumnTransformer(\n",
+    "         [('imputer_mode', SimpleImputer(strategy=strategy), numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', SimpleImputer(strategy=strategy))\n",
+    "])\n",
+    "    X[:, numerical_indexes] = pipeline.fit_transform(X)\n",
     "\n",
-    "if strategy == \"mean\" or strategy == \"median\":\n",
-    "    X[:, numerical_indexes] = estimator.fit_transform(X[:, numerical_indexes])\n",
-    "    columns = columns[~pd.isna(estimator.statistics_)]\n",
-    "    df = pd.DataFrame(data=X, columns=columns[~pd.isna(estimator.statistics_)])\n",
-    "    df[target] = pd.Series(y)\n",
     "elif strategy == \"most_frequent\":\n",
-    "    X = estimator.fit_transform(X)\n",
-    "    df = pd.DataFrame(data=X, columns=columns[~pd.isna(estimator.statistics_)])\n",
-    "    df[target] = pd.Series(y)"
+    "    pipeline = Pipeline(steps=[\n",
+    "    ('handler',\n",
+    "        ColumnTransformer(\n",
+    "         [('imputer_mode', SimpleImputer(strategy=strategy), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', SimpleImputer(strategy=strategy))\n",
+    "])\n",
+    "    X = pipeline.fit_transform(X)\n",
+    "\n",
+    "df = pd.DataFrame(data=X, columns=columns)\n",
+    "df[target] = pd.Series(y)"
    ]
   },
   {
@@ -187,16 +176,16 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"strategy\": strategy,\n",
-    "                  \"numerical_indexes\": numerical_indexes})"
+    "save_model(columns=columns,\n",
+    "           numerical_indexes=numerical_indexes,\n",
+    "           pipeline=pipeline,\n",
+    "           strategy=strategy)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "94c3e6b9-0420-4d48-a5df-2d31fc2ad3af",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -212,8 +201,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "a43611a0-3d85-4bee-b94a-4ab7b01e9e21"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/linear-regression/Inference.ipynb
+++ b/samples/linear-regression/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,20 +44,17 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        \n",
+    "    def class_names(self):\n",
+    "        return [\"estimate\"]\n",
     "\n",
     "    def predict(self, X: np.ndarray, feature_names: Iterable[str], meta: Dict = None) -> Union[np.ndarray, List, str, bytes]:\n",
     "        \"\"\"Takes an array (numpy) X and feature_names and returns an array of predictions.\n",
@@ -59,84 +67,141 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
-    "        return self.estimator.predict(X)"
+    "        return self.pipeline.predict(X)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"boston\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"medv\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"bed7a0e4-27fb-4be2-9f22-7861d15962df\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"crim\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"zn\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"indus\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"chas\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"nox\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 10.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"age\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"dis\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rad\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [1.0, 24.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"tax\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"ptratio\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"black\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"lstat\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"estimate\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -145,60 +210,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"crim\", \"zn\", \"indus\", \"chas\", \"nox\", \"rm\", \"age\", \"dis\", \"rad\", \"tax\", \"ptratio\", \"black\", \"lstat\"],\n",
-    "        \"ndarray\": [\n",
-    "            [0.00632, 18.0, 2.31, 0, 0.5379999999999999, 6.575, 65.2, 4.09, 1, 296, 15.3, 396.9, 4.98]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -214,9 +233,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "0d7db969-c4dc-467b-8a62-a7207b1735eb"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/linear-regression/Training.ipynb
+++ b/samples/linear-regression/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"boston\" #@param {type:\"string\"}\n",
-    "target = \"medv\" #@param {type:\"string\"}\n",
-    "experiment_id = \"bed7a0e4-27fb-4be2-9f22-7861d15962df\" #@param {type:\"string\"}\n",
-    "operator_id = \"2a67f397-8b0e-4fa7-8d29-438f1f6f447a\" #@param {type:\"string\"}"
+    "target = \"medv\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,114 +81,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -230,10 +127,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.linear_model import LinearRegression\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = LinearRegression()\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle_missing_values',\n",
+    "     ColumnTransformer(\n",
+    "        [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "         ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "         remainder='drop')),\n",
+    "    ('handle_categorical_features',\n",
+    "     ColumnTransformer(\n",
+    "         [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', LinearRegression())\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train)    "
    ]
   },
   {
@@ -254,7 +170,7 @@
     "from sklearn.metrics import r2_score\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes R²\n",
     "r2 = r2_score(y_test, y_pred)"
@@ -278,7 +194,8 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, r2_score=r2)"
+    "save_metrics(r2_score=r2)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -380,7 +297,7 @@
     "plt.grid(True)\n",
     "plt.title(\"Error Distribution\")\n",
     "\n",
-    "save_figure(experiment_id=experiment_id, operator_id=operator_id, figure=plt.gcf())"
+    "save_figure(figure=plt.gcf())"
    ]
   },
   {
@@ -401,19 +318,13 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline, columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -429,8 +340,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "2a67f397-8b0e-4fa7-8d29-438f1f6f447a"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/logistic-regression/Inference.ipynb
+++ b/samples/logistic-regression/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,24 +44,18 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None, method: str = \"predict_proba\"):\n",
+    "    def __init__(self, dataset: str = None, target: str = None, method: str = \"predict_proba\"):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "        logger.info(f\"method: {method}\")\n",
     "\n",
     "        self.method = method\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
-    "        self.label_encoder = model[\"label_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        self.label_encoder = model[\"label_encoder\"]\n",
     "\n",
     "    def class_names(self):\n",
     "        if self.method == \"predict_proba\":\n",
@@ -69,26 +74,14 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
     "        if self.method == \"predict_proba\":\n",
-    "            y_pred = self.estimator.predict_proba(X)\n",
+    "            y_pred = self.pipeline.predict_proba(X)\n",
     "        else:\n",
-    "            y_pred = self.estimator.predict(X)\n",
+    "            y_pred = self.pipeline.predict(X)\n",
     "            y_pred = self.label_encoder.inverse_transform(y_pred)\n",
     "\n",
     "        return y_pred"
@@ -98,61 +91,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"7315b5a1-0692-4711-921d-5570f28c2a76\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -161,60 +181,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "7315b5a1-0692-4711-921d-5570f28c2a76",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -230,9 +204,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "07091821-9548-410f-a359-9266c9c75c79"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/logistic-regression/Training.ipynb
+++ b/samples/logistic-regression/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
-    "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"7315b5a1-0692-4711-921d-5570f28c2a76\" #@param {type:\"string\"}\n",
-    "operator_id = \"07091821-9548-410f-a359-9266c9c75c79\" #@param {type:\"string\"}"
+    "target = \"Species\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,114 +81,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -251,10 +148,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = LogisticRegression(solver=\"liblinear\")\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle_missing_values',\n",
+    "     ColumnTransformer(\n",
+    "        [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "         ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "         remainder='drop')),\n",
+    "    ('handle_categorical_features',\n",
+    "     ColumnTransformer(\n",
+    "         [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', LogisticRegression(solver=\"liblinear\"))\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train)   "
    ]
   },
   {
@@ -277,7 +193,7 @@
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes confusion matrix\n",
     "labels = np.unique(y)\n",
@@ -306,7 +222,8 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, confusion_matrix=confusion_matrix)"
+    "save_metrics(confusion_matrix=confusion_matrix)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -327,27 +244,15 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"label_encoder\": label_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(columns=columns,\n",
+    "           label_encoder=label_encoder,\n",
+    "           pipeline=pipeline)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "7315b5a1-0692-4711-921d-5570f28c2a76",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -363,8 +268,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "07091821-9548-410f-a359-9266c9c75c79"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/mlp-classifier/Inference.ipynb
+++ b/samples/mlp-classifier/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,27 +44,20 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None, method: str = \"predict_proba\"):\n",
+    "    def __init__(self, dataset: str = None, target: str = None, method: str = \"predict_proba\"):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
-    "        logger.info(f\"method: {method}\")\n",
     "\n",
     "        self.method = method\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
-    "        self.label_encoder = model[\"label_encoder\"]\n",
+    "        model = load_model()\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
-    "\n",
+    "        self.label_encoder = model[\"label_encoder\"]\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
+    "        \n",
     "    def class_names(self):\n",
-    "        if self.method == \"predict_proba\":\n",
+    "            if self.method == \"predict_proba\":\n",
     "            return self.label_encoder.classes_.tolist()\n",
     "        else:\n",
     "            return [\"class\"]\n",
@@ -69,26 +73,14 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
     "        if self.method == \"predict_proba\":\n",
-    "            y_pred = self.estimator.predict_proba(X)\n",
+    "            y_pred = self.pipeline.predict_proba(X)\n",
     "        else:\n",
-    "            y_pred = self.estimator.predict(X)\n",
+    "            y_pred = self.pipeline.predict(X)\n",
     "            y_pred = self.label_encoder.inverse_transform(y_pred)\n",
     "\n",
     "        return y_pred"
@@ -98,61 +90,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"0805394e-f07f-4b29-ba88-bc46ab074eba\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -161,60 +180,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "0805394e-f07f-4b29-ba88-bc46ab074eba",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -230,9 +203,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "bbc2a87c-4970-4de4-9920-2f385e91f9a3"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/mlp-classifier/Training.ipynb
+++ b/samples/mlp-classifier/Training.ipynb
@@ -23,9 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
-    "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
     "You may also declare custom parameters to set when running an experiment."
@@ -42,9 +39,7 @@
    "outputs": [],
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
-    "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"0805394e-f07f-4b29-ba88-bc46ab074eba\" #@param {type:\"string\"}\n",
-    "operator_id = \"bbc2a87c-4970-4de4-9920-2f385e91f9a3\" #@param {type:\"string\"}"
+    "target = \"Species\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,114 +80,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -251,10 +147,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.neural_network import MLPClassifier\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = MLPClassifier()\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle_missing_values',\n",
+    "     ColumnTransformer(\n",
+    "        [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "         ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "         remainder='drop')),\n",
+    "    ('handle_categorical_features',\n",
+    "     ColumnTransformer(\n",
+    "         [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', MLPClassifier())\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train)    "
    ]
   },
   {
@@ -277,7 +192,7 @@
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes confusion matrix\n",
     "labels = np.unique(y)\n",
@@ -306,7 +221,8 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, confusion_matrix=confusion_matrix)"
+    "save_metrics(confusion_matrix=confusion_matrix)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -327,20 +243,15 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id, \n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"label_encoder\": label_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline,\n",
+    "           label_encoder=label_encoder,\n",
+    "           columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "0805394e-f07f-4b29-ba88-bc46ab074eba",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -356,8 +267,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "bbc2a87c-4970-4de4-9920-2f385e91f9a3"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/mlp-regressor/Inference.ipynb
+++ b/samples/mlp-regressor/Inference.ipynb
@@ -33,20 +33,17 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        \n",
+    "    def class_names(self):\n",
+    "        return [\"estimate\"]\n",
     "\n",
     "    def predict(self, X: np.ndarray, feature_names: Iterable[str], meta: Dict = None) -> Union[np.ndarray, List, str, bytes]:\n",
     "        \"\"\"Takes an array (numpy) X and feature_names and returns an array of predictions.\n",
@@ -59,84 +56,141 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
-    "        return self.estimator.predict(X)"
+    "        return self.pipeline.predict(X)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"boston\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"medv\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"c888e8b5-8401-486f-95a3-0c2807d9b0d7\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"crim\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"zn\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"indus\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"chas\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"nox\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 10.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"age\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"dis\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rad\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [1.0, 24.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"tax\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"ptratio\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"black\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"lstat\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"estimate\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -145,60 +199,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"crim\", \"zn\", \"indus\", \"chas\", \"nox\", \"rm\", \"age\", \"dis\", \"rad\", \"tax\", \"ptratio\", \"black\", \"lstat\"],\n",
-    "        \"ndarray\": [\n",
-    "            [0.00632, 18.0, 2.31, 0, 0.5379999999999999, 6.575, 65.2, 4.09, 1, 296, 15.3, 396.9, 4.98]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -214,9 +222,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "2a67f397-8b0e-4fa7-8d29-438f1f6f447a"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/mlp-regressor/Training.ipynb
+++ b/samples/mlp-regressor/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"boston\" #@param {type:\"string\"}\n",
-    "target = \"medv\" #@param {type:\"string\"}\n",
-    "experiment_id = \"c888e8b5-8401-486f-95a3-0c2807d9b0d7\" #@param {type:\"string\"}\n",
-    "operator_id = \"6f2b8b31-fb13-43f3-b33e-b6546d926252\" #@param {type:\"string\"}"
+    "target = \"medv\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,64 +81,12 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
@@ -152,8 +96,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
+    "## Encode target labels\n",
+    "\n",
+    "The target labels are converted to ordinal integers with value between 0 and n_classes-1."
    ]
   },
   {
@@ -162,37 +107,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from platiagro.featuretypes import DATETIME\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
     "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
+    "label_encoder = LabelEncoder()\n",
+    "y = label_encoder.fit_transform(y)"
    ]
   },
   {
@@ -230,10 +148,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.neural_network import MLPRegressor\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = MLPRegressor()\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle_missing_values',\n",
+    "     ColumnTransformer(\n",
+    "        [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "         ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "         remainder='drop')),\n",
+    "    ('handle_categorical_features',\n",
+    "     ColumnTransformer(\n",
+    "         [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', MLPRegressor())\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train) "
    ]
   },
   {
@@ -254,10 +191,11 @@
     "from sklearn.metrics import r2_score\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes R²\n",
-    "r2 = r2_score(y_test, y_pred)"
+    "r2 = r2_score(y_test, y_pred)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -278,7 +216,7 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, r2_score=r2)"
+    "save_metrics(r2_score=r2)"
    ]
   },
   {
@@ -380,7 +318,7 @@
     "plt.grid(True)\n",
     "plt.title(\"Error Distribution\")\n",
     "\n",
-    "save_figure(experiment_id=experiment_id, operator_id=operator_id, figure=plt.gcf())"
+    "save_figure(figure=plt.gcf())"
    ]
   },
   {
@@ -401,19 +339,13 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline, columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -429,8 +361,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "2a67f397-8b0e-4fa7-8d29-438f1f6f447a"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/normalizer/Inference.ipynb
+++ b/samples/normalizer/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,18 +44,14 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.numerical_indexes = model[\"numerical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
     "\n",
     "    def class_names(self):\n",
     "        return self.columns.tolist()\n",
@@ -60,16 +67,11 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
     "        # Perform Transformation\n",
-    "        if np.ma.any(self.numerical_indexes):\n",
-    "            X[:, self.numerical_indexes] = self.estimator.transform(X[:, self.numerical_indexes])\n",
+    "        X = self.pipeline.transform(X)\n",
     "\n",
     "        return X"
    ]
@@ -78,61 +80,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"TRANSFORMER\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"boston\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"medv\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"e6c07a4e-4902-43c3-b02f-efe8f051cb0c\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make transformations"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -141,57 +170,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"crim\", \"zn\", \"indus\", \"chas\", \"nox\", \"rm\", \"age\", \"dis\", \"rad\", \"tax\", \"ptratio\", \"black\", \"lstat\"],\n",
-    "        \"ndarray\": [\n",
-    "            [0.00632, 18.0, 2.31, 0, 0.5379999999999999, 6.575, 65.2, 4.09, 1, 296, 15.3, 396.9, 4.98]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-microservice | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -210,9 +192,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/normalizer/Training.ipynb
+++ b/samples/normalizer/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -41,10 +39,8 @@
    },
    "outputs": [],
    "source": [
-    "dataset = \"boston\" #@param {type:\"string\"}\n",
-    "target = \"medv\" #@param {type:\"string\"}\n",
-    "experiment_id = \"e6c07a4e-4902-43c3-b02f-efe8f051cb0c\" #@param {type:\"string\"}\n",
-    "operator_id = \"c0deb81a-540e-4d51-bf8f-c332f9b9fd73\" #@param {type:\"string\"}"
+    "dataset = \"b1697d53-f48e-4f3f-b37f-363ede1f5366\" #@param {type:\"string\"}\n",
+    "target = \"median_house_value\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,64 +81,12 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
@@ -161,13 +105,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.pipeline import make_pipeline\n",
     "from sklearn.preprocessing import Normalizer\n",
     "\n",
     "numerical_indexes = (featuretypes == NUMERICAL)\n",
     "estimator = Normalizer()\n",
     "\n",
-    "if np.ma.any(numerical_indexes):\n",
-    "    X[:, numerical_indexes] = estimator.fit_transform(X[:, numerical_indexes])"
+    "pipeline = make_pipeline(\n",
+    "    ColumnTransformer([('handle_numerical_values',\n",
+    "                        SimpleImputer(), numerical_indexes),\n",
+    "                       ('handle_categorical_values',\n",
+    "                        SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "                      remainder='passthrough'),\n",
+    "    ColumnTransformer([('normalizer',\n",
+    "                        Normalizer(),\n",
+    "                        numerical_indexes)],\n",
+    "                        remainder='passthrough')\n",
+    ")\n",
+    "\n",
+    "X = pipeline.fit_transform(X)"
    ]
   },
   {
@@ -208,17 +167,14 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"numerical_indexes\": numerical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline,\n",
+    "           columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "e6c07a4e-4902-43c3-b02f-efe8f051cb0c",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -234,8 +190,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "c0deb81a-540e-4d51-bf8f-c332f9b9fd73"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/random-forest-classifier/Inference.ipynb
+++ b/samples/random-forest-classifier/Inference.ipynb
@@ -33,24 +33,17 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None, method: str = \"predict_proba\"):\n",
+    "    def __init__(self, dataset: str = None, target: str = None, method: str = \"predict_proba\"):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
-    "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "        logger.info(f\"method: {method}\")\n",
     "\n",
     "        self.method = method\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
-    "        self.label_encoder = model[\"label_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        self.label_encoder = model[\"label_encoder\"]\n",
     "\n",
     "    def class_names(self):\n",
     "        if self.method == \"predict_proba\":\n",
@@ -69,26 +62,14 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
     "        if self.method == \"predict_proba\":\n",
-    "            y_pred = self.estimator.predict_proba(X)\n",
+    "            y_pred = self.pipeline.predict_proba(X)\n",
     "        else:\n",
-    "            y_pred = self.estimator.predict(X)\n",
+    "            y_pred = self.pipeline.predict(X)\n",
     "            y_pred = self.label_encoder.inverse_transform(y_pred)\n",
     "\n",
     "        return y_pred"
@@ -98,61 +79,85 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"08d03e85-4a7c-4376-873c-5828ea603e1f\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris Setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"Iris Versicolour\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"Iris Virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -161,60 +166,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "08d03e85-4a7c-4376-873c-5828ea603e1f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -230,9 +189,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "8df0c5c7-10d7-4150-8c62-f51ae2550bf2"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/random-forest-classifier/Training.ipynb
+++ b/samples/random-forest-classifier/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
-    "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"08d03e85-4a7c-4376-873c-5828ea603e1f\" #@param {type:\"string\"}\n",
-    "operator_id = \"8df0c5c7-10d7-4150-8c62-f51ae2550bf2\" #@param {type:\"string\"}"
+    "target = \"Species\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,114 +81,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -251,10 +148,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.ensemble.forest import RandomForestClassifier\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = RandomForestClassifier(n_estimators=10)\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle_missing_values',\n",
+    "     ColumnTransformer(\n",
+    "        [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "         ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "         remainder='drop')),\n",
+    "    ('handle_categorical_features',\n",
+    "     ColumnTransformer(\n",
+    "         [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', RandomForestClassifier(n_estimators=10))\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train) "
    ]
   },
   {
@@ -277,7 +193,7 @@
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes confusion matrix\n",
     "labels = np.unique(y)\n",
@@ -306,7 +222,8 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, confusion_matrix=confusion_matrix)"
+    "save_metrics(confusion_matrix=confusion_matrix)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -327,27 +244,15 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"label_encoder\": label_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline,\n",
+    "           columns=columns,\n",
+    "           label_encoder=label_encoder)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "08d03e85-4a7c-4376-873c-5828ea603e1f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -363,8 +268,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "8df0c5c7-10d7-4150-8c62-f51ae2550bf2"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/random-forest-regressor/Inference.ipynb
+++ b/samples/random-forest-regressor/Inference.ipynb
@@ -33,20 +33,17 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        \n",
+    "    def class_names(self):\n",
+    "        return [\"estimate\"]\n",
     "\n",
     "    def predict(self, X: np.ndarray, feature_names: Iterable[str], meta: Dict = None) -> Union[np.ndarray, List, str, bytes]:\n",
     "        \"\"\"Takes an array (numpy) X and feature_names and returns an array of predictions.\n",
@@ -59,84 +56,141 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
-    "        return self.estimator.predict(X)"
+    "        return self.pipeline.predict(X)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"boston\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"medv\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"d4269baf-e917-4c94-b078-7dc0223a6a1f\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"crim\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"zn\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"indus\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"chas\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"nox\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 10.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"age\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"dis\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rad\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [1.0, 24.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"tax\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"ptratio\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"black\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"lstat\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"estimate\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response.\n"
    ]
   },
   {
@@ -145,60 +199,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"crim\", \"zn\", \"indus\", \"chas\", \"nox\", \"rm\", \"age\", \"dis\", \"rad\", \"tax\", \"ptratio\", \"black\", \"lstat\"],\n",
-    "        \"ndarray\": [\n",
-    "            [0.00632, 18.0, 2.31, 0, 0.5379999999999999, 6.575, 65.2, 4.09, 1, 296, 15.3, 396.9, 4.98]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "d4269baf-e917-4c94-b078-7dc0223a6a1f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -214,9 +222,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "d150e465-f3d5-422d-92e6-409eefe0e399"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/random-forest-regressor/Training.ipynb
+++ b/samples/random-forest-regressor/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"boston\" #@param {type:\"string\"}\n",
-    "target = \"medv\" #@param {type:\"string\"}\n",
-    "experiment_id = \"d4269baf-e917-4c94-b078-7dc0223a6a1f\" #@param {type:\"string\"}\n",
-    "operator_id = \"d150e465-f3d5-422d-92e6-409eefe0e399\" #@param {type:\"string\"}"
+    "target = \"medv\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,114 +81,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -230,10 +127,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.ensemble.forest import RandomForestRegressor\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = RandomForestRegressor(n_estimators=10)\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle_missing_values',\n",
+    "     ColumnTransformer(\n",
+    "        [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "         ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "         remainder='drop')),\n",
+    "    ('handle_categorical_features',\n",
+    "     ColumnTransformer(\n",
+    "         [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', RandomForestRegressor(n_estimators=10))\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train) "
    ]
   },
   {
@@ -254,10 +170,11 @@
     "from sklearn.metrics import r2_score\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes R²\n",
-    "r2 = r2_score(y_test, y_pred)"
+    "r2 = r2_score(y_test, y_pred)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -278,7 +195,7 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, r2_score=r2)"
+    "save_metrics(r2_score=r2)"
    ]
   },
   {
@@ -380,7 +297,7 @@
     "plt.grid(True)\n",
     "plt.title(\"Error Distribution\")\n",
     "\n",
-    "save_figure(experiment_id=experiment_id, operator_id=operator_id, figure=plt.gcf())"
+    "save_figure(figure=plt.gcf())"
    ]
   },
   {
@@ -401,19 +318,13 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline, columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "d4269baf-e917-4c94-b078-7dc0223a6a1f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -429,8 +340,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "d150e465-f3d5-422d-92e6-409eefe0e399"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/robust-scaler/Inference.ipynb
+++ b/samples/robust-scaler/Inference.ipynb
@@ -16,6 +16,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare parameters\n",
+    "Components may declare (and use) these default parameters:\n",
+    "- dataset\n",
+    "- target\n",
+    "\n",
+    "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
+    "\n",
+    "You may also declare custom parameters to set when running an experiment."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,22 +47,21 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
     "        self.numerical_indexes = model[\"numerical_indexes\"]\n",
     "\n",
     "    def class_names(self):\n",
-    "        return self.columns\n",
+    "        return self.columns.tolist()\n",
     "\n",
     "    def predict(self, X: np.ndarray, feature_names: Iterable[str], meta: Dict = None) -> Union[np.ndarray, List, str, bytes]:\n",
-    "        \"\"\"Takes an array (numpy) X and feature_names and scales features.\n",
+    "        \"\"\"Takes an array (numpy) X and feature_names and normalizes samples to unit norm.\n",
     "\n",
     "        Args:\n",
     "            X (numpy.array): Array-like with data.\n",
@@ -62,8 +75,7 @@
     "        X = df[self.columns].to_numpy()\n",
     "\n",
     "        # Perform Transformation\n",
-    "        if np.ma.any(self.numerical_indexes):\n",
-    "            X[:, self.numerical_indexes] = self.estimator.transform(X[:, self.numerical_indexes])\n",
+    "        X[:, self.numerical_indexes] = self.pipeline.transform(X[:, self.numerical_indexes])\n",
     "\n",
     "        return X"
    ]
@@ -72,61 +84,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"94c3e6b9-0420-4d48-a5df-2d31fc2ad3af\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make transformations"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -135,60 +174,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-microservice | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "94c3e6b9-0420-4d48-a5df-2d31fc2ad3af",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -204,8 +197,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "a43611a0-3d85-4bee-b94a-4ab7b01e9e21"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/robust-scaler/Training.ipynb
+++ b/samples/robust-scaler/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
-    "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"94c3e6b9-0420-4d48-a5df-2d31fc2ad3af\" #@param {type:\"string\"}\n",
-    "operator_id = \"a43611a0-3d85-4bee-b94a-4ab7b01e9e21\" #@param {type:\"string\"}"
+    "target = \"Species\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -96,16 +92,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
+    "columns = df.columns.to_numpy()\n",
     "featuretypes = np.array(featuretypes)\n",
+    "target_index = np.argwhere(columns == target)\n",
+    "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
    ]
   },
@@ -124,6 +120,8 @@
    "source": [
     "import pandas as pd\n",
     "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.pipeline import Pipeline\n",
     "from sklearn.preprocessing import RobustScaler\n",
     "\n",
     "# selects the indexes of numerical features\n",
@@ -131,12 +129,15 @@
     "\n",
     "estimator = RobustScaler()\n",
     "\n",
-    "if np.ma.any(numerical_indexes):\n",
-    "    X[:, numerical_indexes] = estimator.fit_transform(X[:, numerical_indexes])\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('estimator', RobustScaler())\n",
+    "])\n",
     "\n",
-    "    # Put data back in a pandas.DataFrame\n",
-    "    df = pd.DataFrame(data=X, columns=columns)\n",
-    "    df[target] = pd.Series(y)"
+    "X[:, numerical_indexes] = pipeline.fit_transform(X[:, numerical_indexes])\n",
+    "\n",
+    "# Put data back in a pandas.DataFrame\n",
+    "df = pd.DataFrame(data=X, columns=columns)\n",
+    "df[target] = pd.Series(y)"
    ]
   },
   {
@@ -177,15 +178,15 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"columns\": columns.tolist(),\n",
-    "                  \"numerical_indexes\": numerical_indexes})"
+    "save_model(pipeline=pipeline,\n",
+    "           columns=columns,\n",
+    "           numerical_indexes=numerical_indexes)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "94c3e6b9-0420-4d48-a5df-2d31fc2ad3af",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -201,8 +202,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "a43611a0-3d85-4bee-b94a-4ab7b01e9e21"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/svc/Inference.ipynb
+++ b/samples/svc/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -28,6 +39,9 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from platiagro import load_model\n",
+    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL, infer_featuretypes\n",
+    "from sklearn.exceptions import NotFittedError \n",
+    "from sklearn.utils.validation import check_is_fitted\n",
     "\n",
     "logger = logging.getLogger(__name__)\n",
     "\n",
@@ -43,14 +57,9 @@
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
     "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.label_encoder = model[\"label_encoder\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
     "\n",
     "    def class_names(self):\n",
     "        if self.method == \"predict_proba\":\n",
@@ -69,26 +78,14 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
     "        if self.method == \"predict_proba\":\n",
-    "            y_pred = self.estimator.predict_proba(X)\n",
+    "            y_pred = self.pipeline.predict_proba(X)\n",
     "        else:\n",
-    "            y_pred = self.estimator.predict(X)\n",
+    "            y_pred = self.pipeline.predict(X)\n",
     "            y_pred = self.label_encoder.inverse_transform(y_pred)\n",
     "\n",
     "        return y_pred"
@@ -98,61 +95,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"iris\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"Species\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"1550eac4-931b-41f1-bf58-a958b2249620\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"SepalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"SepalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 4.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalLengthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 7.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"PetalWidthCm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.1, 3.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"Iris-setosa\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-versicolor\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "                {\n",
+    "            \"name\": \"Iris-virginica\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -161,60 +185,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"SepalLengthCm\",\"SepalWidthCm\",\"PetalLengthCm\",\"PetalWidthCm\"],\n",
-    "        \"ndarray\": [\n",
-    "            [5.1,3.5,1.4,0.2]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "1550eac4-931b-41f1-bf58-a958b2249620",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -230,9 +208,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "c0deb81a-540e-4d51-bf8f-c332f9b9fd73"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/svc/Training.ipynb
+++ b/samples/svc/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"iris\" #@param {type:\"string\"}\n",
-    "target = \"Species\" #@param {type:\"string\"}\n",
-    "experiment_id = \"1550eac4-931b-41f1-bf58-a958b2249620\" #@param {type:\"string\"}\n",
-    "operator_id = \"c0deb81a-540e-4d51-bf8f-c332f9b9fd73\" #@param {type:\"string\"}"
+    "target = \"Species\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,114 +81,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -251,10 +148,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sklearn.compose import ColumnTransformer\n",
     "from sklearn.svm import SVC\n",
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = SVC(gamma=\"auto\", probability=True)\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle missing values', ColumnTransformer(\n",
+    "    [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "     ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "    remainder='drop')),\n",
+    "    ('handle categorical features', ColumnTransformer(\n",
+    "    [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "    remainder='passthrough')),\n",
+    "    ('estimator', SVC(gamma=\"auto\", probability=True)),\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train)"
    ]
   },
   {
@@ -277,7 +191,7 @@
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes confusion matrix\n",
     "labels = np.unique(y)\n",
@@ -306,7 +220,8 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, confusion_matrix=confusion_matrix)"
+    "save_metrics(confusion_matrix=confusion_matrix)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -327,20 +242,15 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"label_encoder\": label_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline,\n",
+    "           label_encoder=label_encoder,\n",
+    "           columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "1550eac4-931b-41f1-bf58-a958b2249620",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -356,8 +266,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "c0deb81a-540e-4d51-bf8f-c332f9b9fd73"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/svr/Inference.ipynb
+++ b/samples/svr/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -33,20 +44,17 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, Encoders, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
-    "        self.feature_encoder = model[\"feature_encoder\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
-    "        self.datetime_indexes = model[\"datetime_indexes\"]\n",
-    "        self.categorical_indexes = model[\"categorical_indexes\"]\n",
-    "        self.numerical_nan_replacement = model[\"numerical_nan_replacement\"]\n",
-    "        self.categorical_nan_replacement = model[\"categorical_nan_replacement\"]\n",
+    "        \n",
+    "    def class_names(self):\n",
+    "        return [\"estimate\"]\n",
     "\n",
     "    def predict(self, X: np.ndarray, feature_names: Iterable[str], meta: Dict = None) -> Union[np.ndarray, List, str, bytes]:\n",
     "        \"\"\"Takes an array (numpy) X and feature_names and returns an array of predictions.\n",
@@ -59,84 +67,141 @@
     "        # Put data in a pandas.DataFrame\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",
-    "        # Replace NaNs\n",
-    "        df.fillna(self.categorical_nan_replacement, inplace=True)\n",
-    "        df.fillna(self.numerical_nan_replacement, inplace=True)\n",
-    "\n",
     "        # Put data back in a numpy.ndarray\n",
     "        X = df[self.columns].to_numpy()\n",
     "\n",
-    "        # Remove datetime features\n",
-    "        X = X[:, np.where(~self.datetime_indexes)[0]]\n",
-    "\n",
-    "        # Encode categorical features\n",
-    "        if np.ma.any(self.categorical_indexes):\n",
-    "            X[:, self.categorical_indexes] = \\\n",
-    "                self.feature_encoder.transform(X[:, self.categorical_indexes])\n",
-    "\n",
     "        # Perform Prediction\n",
-    "        return self.estimator.predict(X)"
+    "        return self.pipeline.predict(X)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"boston\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"medv\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"50ecf2eb-b805-4629-aea4-66053ed9ec8c\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"crim\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"zn\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"indus\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"chas\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"nox\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 10.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"age\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"dis\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rad\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [1.0, 24.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"tax\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"ptratio\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"black\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"lstat\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"estimate\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make predictions"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -145,60 +210,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"crim\", \"zn\", \"indus\", \"chas\", \"nox\", \"rm\", \"age\", \"dis\", \"rad\", \"tax\", \"ptratio\", \"black\", \"lstat\"],\n",
-    "        \"ndarray\": [\n",
-    "            [0.00632, 18.0, 2.31, 0, 0.5379999999999999, 6.575, 65.2, 4.09, 1, 296, 15.3, 396.9, 4.98]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-mic | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "50ecf2eb-b805-4629-aea4-66053ed9ec8c",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -214,9 +233,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "104740b1-82c1-4321-9bd3-b2ef931f56f1"
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/svr/Training.ipynb
+++ b/samples/svr/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -42,9 +40,7 @@
    "outputs": [],
    "source": [
     "dataset = \"boston\" #@param {type:\"string\"}\n",
-    "target = \"medv\" #@param {type:\"string\"}\n",
-    "experiment_id = \"50ecf2eb-b805-4629-aea4-66053ed9ec8c\" #@param {type:\"string\"}\n",
-    "operator_id = \"104740b1-82c1-4321-9bd3-b2ef931f56f1\" #@param {type:\"string\"}"
+    "target = \"medv\" #@param {type:\"string\"}"
    ]
   },
   {
@@ -85,114 +81,15 @@
    "source": [
     "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
-    "featuretypes = np.array(featuretypes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace NaN values\n",
-    "Remove features that all values are NA.<br>\n",
-    "If some values are missing, then use the mean for numerical features, and the mode for categorical features."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "na_free = df.dropna(axis=\"columns\", how=\"all\")\n",
-    "only_na = df.loc[:, ~df.columns.isin(na_free.columns)]\n",
-    "\n",
-    "featuretypes = featuretypes[df.columns.isin(na_free.columns)]\n",
-    "df = na_free"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import CATEGORICAL, NUMERICAL\n",
-    "\n",
-    "numerical_indexes = (featuretypes == NUMERICAL)\n",
-    "numerical_nan_replacement = df.iloc[:, numerical_indexes].mean(axis=0)\n",
-    "df.fillna(numerical_nan_replacement, inplace=True)\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "categorical_nan_replacement = df.iloc[:, categorical_indexes].mode(axis=0).iloc[0]\n",
-    "df.fillna(categorical_nan_replacement, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = df.drop(target, axis=1).to_numpy()\n",
     "columns = df.columns.to_numpy()\n",
+    "featuretypes = np.array(featuretypes)\n",
     "target_index = np.argwhere(columns == target)\n",
     "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Remove datetime features\n",
-    "Datetime columns require separate preprocessing or feature extraction steps."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro.featuretypes import DATETIME\n",
-    "\n",
-    "datetime_indexes = (featuretypes == DATETIME)\n",
-    "X = X[:, np.where(~datetime_indexes)[0]]\n",
-    "featuretypes = np.delete(featuretypes, np.where(datetime_indexes))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Encode categorical features\n",
-    "\n",
-    "Many machine learning algorithms cannot operate on categorical data directly. They require all input variables and output variables to be numeric.<br>\n",
-    "This means that categorical data must be converted to a numerical form.<br>\n",
-    "The features are converted to ordinal integers. This results in a single column of integers (0 to n_categories - 1) per feature."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import OrdinalEncoder\n",
-    "\n",
-    "categorical_indexes = (featuretypes == CATEGORICAL)\n",
-    "feature_encoder = OrdinalEncoder()\n",
-    "\n",
-    "if np.ma.any(categorical_indexes):\n",
-    "    X[:, categorical_indexes] = feature_encoder.fit_transform(X[:, categorical_indexes])"
    ]
   },
   {
@@ -230,10 +127,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.impute import SimpleImputer\n",
     "from sklearn.svm import SVR\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OrdinalEncoder\n",
     "\n",
-    "estimator = SVR(gamma=\"auto\")\n",
-    "estimator.fit(X_train, y_train)    "
+    "numerical_indexes = (featuretypes == NUMERICAL)\n",
+    "\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('handle_missing_values',\n",
+    "     ColumnTransformer(\n",
+    "        [('imputer_mean', SimpleImputer(strategy='mean'), numerical_indexes),\n",
+    "         ('imputer_mode', SimpleImputer(strategy='most_frequent'), ~numerical_indexes)],\n",
+    "         remainder='drop')),\n",
+    "    ('handle_categorical_features',\n",
+    "     ColumnTransformer(\n",
+    "         [('feature_encoder', OrdinalEncoder(), ~numerical_indexes)],\n",
+    "         remainder='passthrough')),\n",
+    "    ('estimator', SVR(gamma=\"auto\"))\n",
+    "])\n",
+    "\n",
+    "pipeline.fit(X_train, y_train)    "
    ]
   },
   {
@@ -254,10 +170,11 @@
     "from sklearn.metrics import r2_score\n",
     "\n",
     "# uses the model to make predictions on the Test Dataset\n",
-    "y_pred = estimator.predict(X_test)\n",
+    "y_pred = pipeline.predict(X_test)\n",
     "\n",
     "# computes R²\n",
-    "r2 = r2_score(y_test, y_pred)"
+    "r2 = r2_score(y_test, y_pred)\n",
+    "pipeline.fit(X, y)"
    ]
   },
   {
@@ -278,7 +195,7 @@
    "source": [
     "from platiagro import save_metrics\n",
     "\n",
-    "save_metrics(experiment_id=experiment_id, operator_id=operator_id, r2_score=r2)"
+    "save_metrics(r2_score=r2)"
    ]
   },
   {
@@ -380,7 +297,7 @@
     "plt.grid(True)\n",
     "plt.title(\"Error Distribution\")\n",
     "\n",
-    "save_figure(experiment_id=experiment_id, operator_id=operator_id, figure=plt.gcf())"
+    "save_figure(figure=plt.gcf())"
    ]
   },
   {
@@ -401,19 +318,13 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"feature_encoder\": feature_encoder,\n",
-    "                  \"columns\": columns,\n",
-    "                  \"datetime_indexes\": datetime_indexes,\n",
-    "                  \"categorical_indexes\": categorical_indexes,\n",
-    "                  \"numerical_nan_replacement\": numerical_nan_replacement,\n",
-    "                  \"categorical_nan_replacement\": categorical_nan_replacement})"
+    "save_model(pipeline=pipeline, columns=columns)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "50ecf2eb-b805-4629-aea4-66053ed9ec8c",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -429,8 +340,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "104740b1-82c1-4321-9bd3-b2ef931f56f1"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/variance-threshold/Inference.ipynb
+++ b/samples/variance-threshold/Inference.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping Model\n",
+    "\n",
+    "Allows your component to expose a service over REST.\n",
+    "\n",
+    "To wrap your model [follow the instructions](https://docs.seldon.io/projects/seldon-core/en/v0.3.0/python/python_component.html) for your chosen language or toolkit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -32,14 +43,13 @@
     "\n",
     "\n",
     "class Model(object):\n",
-    "    def __init__(self, dataset: str = None, target: str = None, experiment_id: str = None):\n",
+    "    def __init__(self, dataset: str = None, target: str = None,):\n",
     "        logger.info(f\"dataset: {dataset}\")\n",
     "        logger.info(f\"target: {target}\")\n",
-    "        logger.info(f\"experiment_id: {experiment_id}\")\n",
     "\n",
     "        # Load Artifacts: Estimator, etc\n",
-    "        model = load_model(experiment_id=experiment_id)\n",
-    "        self.estimator = model[\"estimator\"]\n",
+    "        model = load_model()\n",
+    "        self.pipeline = model[\"pipeline\"]\n",
     "        self.columns = model[\"columns\"]\n",
     "        self.numerical_indexes = model[\"numerical_indexes\"]\n",
     "\n",
@@ -56,7 +66,7 @@
     "        \"\"\"\n",
     "        # Perform Transformation\n",
     "        if np.ma.any(self.numerical_indexes):\n",
-    "            X_thr = self.estimator.transform(X[:, self.numerical_indexes])\n",
+    "            X_thr = self.pipeline.transform(X[:, self.numerical_indexes])\n",
     "            X = np.concatenate((X[:, ~self.numerical_indexes], X_thr), axis=1)\n",
     "\n",
     "        return X"
@@ -66,61 +76,130 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deployment Test\n",
+    "## API Contract\n",
     "\n",
-    "It simulates a model deployed by PlatIAgro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile env.sh\n",
-    "export MODEL_NAME=\"Model\"\n",
-    "export API_TYPE=\"REST\"\n",
-    "export SERVICE_TYPE=\"MODEL\"\n",
-    "export PERSISTENCE=0\n",
-    "export LOG_LEVEL=\"DEBUG\"\n",
-    "export PARAMETERS='[\n",
-    "{\"type\":\"STRING\",\"name\":\"dataset\",\"value\":\"boston\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"target\",\"value\":\"medv\"},\n",
-    "{\"type\":\"STRING\",\"name\":\"experiment_id\",\"value\":\"881c6caa-2fa8-4165-b408-9eabceb5f752\"}]'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "source env.sh\n",
-    "seldon-core-microservice \"$MODEL_NAME\" \"$API_TYPE\" \\\n",
-    "    --service-type \"$SERVICE_TYPE\" \\\n",
-    "    --persistence \"$PERSISTENCE\" \\\n",
-    "    --parameters \"$PARAMETERS\" \\\n",
-    "    --log-level \"$LOG_LEVEL\" > log.txt 2>&1 &\n",
+    "There are two sections:\n",
     "\n",
-    "ATTEMPT=0\n",
-    "until $(curl --output /dev/null --silent --head --fail http://localhost:5000/health/ping); do\n",
-    "    # exit process if not healthy after 10 seconds\n",
-    "    if [ \"$ATTEMPT\" -gt 10 ]; then\n",
-    "        cat log.txt\n",
-    "        exit 1\n",
-    "    fi\n",
-    "    ATTEMPT=$((ATTEMPT + 1))\n",
-    "    sleep 1\n",
-    "done\n",
-    "echo \"Deployment successful. Waiting for requests.\""
+    "- `features` : The feature array you intend to send in a request\n",
+    "- `targets` : The response you expect back\n",
+    "\n",
+    "Each section has a list of definitions. Each definition consists of:\n",
+    "\n",
+    "- `name` : String : The name of the feature\n",
+    "- `ftype` : one of CONTINUOUS, CATEGORICAL : the type of the feature\n",
+    "- `dtype` : One of FLOAT, INT : Required for ftype CONTINUOUS : What type of feature to create\n",
+    "- `values` : list of Strings : Required for ftype CATEGORICAL : The possible categorical values\n",
+    "- `range` : list of two numbers : Optional for ftype CONTINUOUS : The range of values (inclusive) that a continuous value can take\n",
+    "- `repeat` : integer : Optional value for how many times to repeat this value\n",
+    "- `shape` : array of integers : Optional value for the shape of array to coerce the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile contract.json\n",
+    "{\n",
+    "    \"features\": [\n",
+    "        {\n",
+    "            \"name\": \"crim\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"zn\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"indus\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"chas\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"nox\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rm\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 10.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"age\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"dis\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"rad\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [1.0, 24.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"tax\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"ptratio\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"black\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 1000.0]\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"lstat\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ],\n",
+    "    \"targets\": [\n",
+    "        {\n",
+    "            \"name\": \"estimate\",\n",
+    "            \"dtype\": \"FLOAT\",\n",
+    "            \"ftype\": \"continuous\",\n",
+    "            \"range\": [0.0, 100.0]\n",
+    "        }\n",
+    "    ]\n",
+    "}"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Make transformations"
+    "## Test Deployment\n",
+    "\n",
+    "Starts a service wrapping a Model, sends a request to the service, and shows the response."
    ]
   },
   {
@@ -129,60 +208,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "curl -sSL localhost:5000/predict --data-binary @- << EOF\n",
-    "json={\n",
-    "    \"data\": {\n",
-    "        \"names\": [\"crim\", \"zn\", \"indus\", \"chas\", \"nox\", \"rm\", \"age\", \"dis\", \"rad\", \"tax\", \"ptratio\", \"black\", \"lstat\"],\n",
-    "        \"ndarray\": [\n",
-    "            [0.00632, 18.0, 2.31, 0, 0.5379999999999999, 6.575, 65.2, 4.09, 1, 296, 15.3, 396.9, 4.98]\n",
-    "        ]\n",
-    "    }\n",
-    "}\n",
-    "EOF"
+    "from platiagro.deployment import test_deployment\n",
+    "\n",
+    "test_deployment(\"contract.json\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View logs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat log.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Clean up the test"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ps -ef | grep [s]eldon-core-microservice | awk '{print $2}' | xargs -r kill"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "experiment_id": "881c6caa-2fa8-4165-b408-9eabceb5f752",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -198,8 +231,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "14e5479e-2875-400b-ab46-0ec73c36bcce"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/variance-threshold/Training.ipynb
+++ b/samples/variance-threshold/Training.ipynb
@@ -23,8 +23,6 @@
     "Components may declare (and use) these default parameters:\n",
     "- dataset\n",
     "- target\n",
-    "- experiment_id\n",
-    "- operator_id\n",
     "\n",
     "Use these parameters to load/save datasets, models, metrics, and figures with the help of [PlatIAgro SDK](https://platiagro.github.io/sdk/).\n",
     "\n",
@@ -43,8 +41,6 @@
    "source": [
     "dataset = \"boston\" #@param {type:\"string\"}\n",
     "target = \"medv\" #@param {type:\"string\"}\n",
-    "experiment_id = \"881c6caa-2fa8-4165-b408-9eabceb5f752\" #@param {type:\"string\"}\n",
-    "operator_id = \"14e5479e-2875-400b-ab46-0ec73c36bcce\" #@param {type:\"string\"}\n",
     "threshold = 0.0 #@param {type:\"number\", label:\"Limiar\", description:\"Atributos com variância menor que o limiar serão removidos.\"}"
    ]
   },
@@ -71,19 +67,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "columns = df.columns.to_numpy()\n",
-    "target_index = np.argwhere(columns == target)\n",
-    "columns = np.delete(columns, target_index)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -97,16 +80,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "from platiagro import stat_dataset\n",
-    "from platiagro.featuretypes import infer_featuretypes\n",
     "\n",
-    "try:\n",
-    "    metadata = stat_dataset(name=dataset)\n",
-    "    featuretypes = metadata[\"featuretypes\"]\n",
-    "except KeyError:\n",
-    "    featuretypes = infer_featuretypes(df)\n",
+    "metadata = stat_dataset(name=dataset)\n",
+    "featuretypes = metadata[\"featuretypes\"]\n",
     "\n",
+    "columns = df.columns.to_numpy()\n",
     "featuretypes = np.array(featuretypes)\n",
+    "target_index = np.argwhere(columns == target)\n",
+    "columns = np.delete(columns, target_index)\n",
     "featuretypes = np.delete(featuretypes, target_index)"
    ]
   },
@@ -125,24 +108,29 @@
    "source": [
     "import pandas as pd\n",
     "from platiagro.featuretypes import NUMERICAL\n",
+    "from sklearn.compose import ColumnTransformer\n",
     "from sklearn.feature_selection import VarianceThreshold\n",
+    "from sklearn.pipeline import Pipeline\n",
     "\n",
     "# selects the indexes of numerical features\n",
     "numerical_indexes = (featuretypes == NUMERICAL)\n",
     "\n",
     "estimator = VarianceThreshold(threshold=threshold)\n",
     "\n",
-    "if np.ma.any(numerical_indexes):\n",
-    "    X_thr = estimator.fit_transform(X[:, numerical_indexes])\n",
-    "    X = np.concatenate((X[:, ~numerical_indexes], X_thr), axis=1)\n",
+    "pipeline = Pipeline(steps=[\n",
+    "    ('estimator', VarianceThreshold(threshold=threshold))\n",
+    "])\n",
     "\n",
-    "    # apply the indexes to get the new column sequence\n",
-    "    columns = np.concatenate((columns[~numerical_indexes], \n",
-    "                              columns[numerical_indexes][estimator.get_support()]))\n",
+    "X_thr = pipeline.fit_transform(X[:, numerical_indexes])\n",
+    "X = np.concatenate((X[:, ~numerical_indexes], X_thr), axis=1)\n",
     "\n",
-    "    # Put data back in a pandas.DataFrame\n",
-    "    df = pd.DataFrame(data=X, columns=columns)\n",
-    "    df[target] = pd.Series(y)"
+    "# apply the indexes to get the new column sequence\n",
+    "columns = np.concatenate((columns[~numerical_indexes], \n",
+    "                          columns[numerical_indexes][pipeline.named_steps.estimator.get_support()]))\n",
+    "\n",
+    "# Put data back in a pandas.DataFrame\n",
+    "df = pd.DataFrame(data=X, columns=columns)\n",
+    "df[target] = pd.Series(y)"
    ]
   },
   {
@@ -183,15 +171,15 @@
    "source": [
     "from platiagro import save_model\n",
     "\n",
-    "save_model(experiment_id=experiment_id,\n",
-    "           model={\"estimator\": estimator,\n",
-    "                  \"columns\": columns.tolist(),\n",
-    "                  \"numerical_indexes\": numerical_indexes})"
+    "save_model(pipeline=pipeline,\n",
+    "           columns=columns.tolist(),\n",
+    "           numerical_indexes=numerical_indexes)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "experiment_id": "881c6caa-2fa8-4165-b408-9eabceb5f752",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -207,8 +195,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
-  }
+   "version": "3.7.6"
+  },
+  "operator_id": "14e5479e-2875-400b-ab46-0ec73c36bcce"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -13,6 +13,7 @@ UPDATED_AT = "2000-01-01 00:00:00"
 UPDATED_AT_ISO = "2000-01-01T00:00:00"
 EXPERIMENT_ID = str(uuid4())
 EXPERIMENT_NAME = "Novo experimento"
+DESCRIPTION= "Description"
 
 
 class TestProjects(TestCase):
@@ -20,8 +21,8 @@ class TestProjects(TestCase):
         self.maxDiff = None
         conn = engine.connect()
         text = (
-            f"INSERT INTO projects (uuid, name, created_at, updated_at) "
-            f"VALUES ('{PROJECT_ID}', '{NAME}', '{CREATED_AT}', '{UPDATED_AT}')"
+            f"INSERT INTO projects (uuid, name, created_at, updated_at, description) "
+            f"VALUES ('{PROJECT_ID}', '{NAME}', '{CREATED_AT}', '{UPDATED_AT}', '{DESCRIPTION}')"
         )
         conn.execute(text)
 
@@ -29,6 +30,7 @@ class TestProjects(TestCase):
             f"INSERT INTO experiments (uuid, name, project_id, dataset, target, position, is_active, created_at, updated_at) "
             f"VALUES ('{EXPERIMENT_ID}', '{EXPERIMENT_NAME}', '{PROJECT_ID}', null, null, 0, 1, '{CREATED_AT}', '{UPDATED_AT}')"
         )
+
         conn.execute(text)
         conn.close()
 
@@ -57,11 +59,13 @@ class TestProjects(TestCase):
 
             rv = c.post("/projects", json={
                 "name": "foo",
+                "description":"description",
             })
             result = rv.get_json()
             result_experiments = result.pop("experiments")
             expected = {
                 "name": "foo",
+                "description": "description",
             }
             # uuid, created_at, updated_at are machine-generated
             # we assert they exist, but we don't assert their values
@@ -102,6 +106,7 @@ class TestProjects(TestCase):
                 "name": NAME,
                 "createdAt": CREATED_AT_ISO,
                 "updatedAt": UPDATED_AT_ISO,
+                "description": DESCRIPTION,
             }
             self.assertDictEqual(expected, result)
 
@@ -145,6 +150,7 @@ class TestProjects(TestCase):
                 "uuid": PROJECT_ID,
                 "name": "bar",
                 "createdAt": CREATED_AT_ISO,
+                "description": DESCRIPTION,
             }
             machine_generated = ["updatedAt"]
             for attr in machine_generated:


### PR DESCRIPTION
- Change in the load_model method call, removing fields that were previously mandatory (experiment_id and operator_id)
- Removing the "Make predictions" cell and changing the Deployment Test method, removing bash coding, making it more visually pleasing for those using it

Refactoring - Training.ipynb
- Replace cells that handle NaN, categorical and datetime features with sklearn.pipeline class to summarize the steps for handling dataset values
- Remove an explicit declaration from the variables referring to experiment_id and operator_id, which becomes optional, making them the property of the notebook's metadata
- Change in the call to the save_model method, where it starts saving the Pipeline Object generated by sklearn.pipeline