### PR TITLE
Fix/sort components projects

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -644,6 +644,46 @@ components:
       items:
         oneOf:
           - $ref: "#/components/schemas/Component"
+    ComponentEmpty:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+    ComponentCopyFrom:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        copyFrom:
+          type: string
+          format: uuid
+    ComponentNotebooks:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        inferenceNotebook:
+          type: object
+        trainingNotebook:
+          type: object
     Parameter:
       type: object
       properties:
@@ -789,33 +829,43 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              name:
-                type: string
-              description:
-                type: string
-              tags:
-                type: array
-                items:
-                  type: string
-              copyFrom:
-                type: string
-                format: uuid
+            oneOf:
+              - $ref: '#/components/schemas/ComponentEmpty'
+              - $ref: '#/components/schemas/ComponentCopyFrom'
+              - $ref: '#/components/schemas/ComponentNotebooks'
+          examples:
+            empty:
+              summary: Empty notebooks
+              value:
+                name: string
+                description: string
+                tags: ['DEFAULT']
+            copyFrom:
+              summary: Notebooks from another component
+              value:
+                name: string
+                description: string
+                tags: ['DEFAULT']
+                copyFrom: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+            notebook:
+              summary: Notebooks from request body
+              value:
+                name: string
+                description: string
+                tags: ['DEFAULT']
+                inferenceNotebook: {"cells":[{"cell_type":"code","execution_count":null,"metadata":{},"outputs":[],"source":[]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.6.9"}},"nbformat":4,"nbformat_minor":4}
+                trainingNotebook: {"cells":[{"cell_type":"code","execution_count":null,"metadata":{},"outputs":[],"source":[]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.6.9"}},"nbformat":4,"nbformat_minor":4}
     ComponentPatch:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              name:
-                type: string
-              description:
-                type: string
-              tags:
-                type: array
-                items:
-                  type: string
+            $ref: '#/components/schemas/ComponentNotebooks'
+          example:
+            name: string
+            description: string
+            tags: ['DEFAULT']
+            inferenceNotebook: {"cells":[{"cell_type":"code","execution_count":null,"metadata":{},"outputs":[],"source":[]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.6.9"}},"nbformat":4,"nbformat_minor":4}
+            trainingNotebook: {"cells":[{"cell_type":"code","execution_count":null,"metadata":{},"outputs":[],"source":[]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.6.9"}},"nbformat":4,"nbformat_minor":4}
     Project:
       content:
         application/json:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -33,7 +33,7 @@ tags:
 paths:
   /components:
     get:
-      summary: "List all components."
+      summary: "List all components sorted by name in ascending order."
       tags:
         - "Components"
       responses:
@@ -142,7 +142,7 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
   /projects:
     get:
-      summary: "List all projects."
+      summary: "List all projects sorted by name in ascending order."
       tags:
         - "Projects"
       responses:
@@ -231,7 +231,7 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
   /projects/{projectId}/experiments:
     get:
-      summary: "List all experiments."
+      summary: "List all experiments sorted by position in ascending order."
       tags:
         - "Experiments"
       parameters:
@@ -351,7 +351,7 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
   /projects/{projectId}/experiments/{experimentId}/operators:
     get:
-      summary: "List all operators."
+      summary: "List all operators sorted by position in ascending order."
       tags:
         - "Operators"
       parameters:
@@ -524,7 +524,7 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
   /templates:
     get:
-      summary: "List all templates."
+      summary: "List all templates sorted by name in ascending order."
       tags:
         - "Templates"
       responses:

--- a/projects/controllers/components.py
+++ b/projects/controllers/components.py
@@ -26,9 +26,11 @@ def list_components():
     """Lists all components from our database.
 
     Returns:
-        A list of all components.
+        A list of all components sorted by name in ascending order.
     """
-    components = Component.query.all()
+    components = db_session.query(Component) \
+        .order_by(Component.name.asc()) \
+        .all()
     return [component.as_dict() for component in components]
 
 

--- a/projects/controllers/projects.py
+++ b/projects/controllers/projects.py
@@ -17,9 +17,11 @@ def list_projects():
     """Lists all projects from our database.
 
     Returns:
-        A list of all projects.
+        A list of all projects sorted by name in ascending order.
     """
-    projects = Project.query.all()
+    projects = db_session.query(Project) \
+        .order_by(Project.name.asc()) \
+        .all()
     return [project.as_dict() for project in projects]
 
 

--- a/projects/controllers/templates.py
+++ b/projects/controllers/templates.py
@@ -16,7 +16,9 @@ def list_templates():
     Returns:
         A list of all templates.
     """
-    templates = Template.query.all()
+    templates = db_session.query(Template) \
+        .order_by(Template.name.asc()) \
+        .all()
     return [template.as_dict() for template in templates]
 
 

--- a/projects/object_storage.py
+++ b/projects/object_storage.py
@@ -34,6 +34,9 @@ def get_object(source):
     Args:
         source (str): the path to source object.
     """
+    # ensures MinIO bucket exists
+    make_bucket(BUCKET_NAME)
+
     data = MINIO_CLIENT.get_object(
         bucket_name=BUCKET_NAME,
         object_name=source,

--- a/projects/samples.py
+++ b/projects/samples.py
@@ -41,5 +41,5 @@ def read_notebook(notebook_path):
         The notebook content as bytes.
     """
     with open(notebook_path, "rb") as f:
-        notebook = f.read()
+        notebook = load(f)
     return notebook


### PR DESCRIPTION
- Sorts components by name asc. when listing all

The "components shelf" in a project must be sorted by name for
better user experience.

- Sorts projects by name asc. when listing all

The projects table must be sorted by name for better user experience.

- Sorts templates by name asc. when listing all

The "templates shelf" in a project must be sorted by name for better
user experience.

-  Updates Swagger UI docs

Makes explicit GET /<resource> requests returns elements sorted by
some criteria.

- Fix POST/PATCH bug when notebook is sent

trainingNotebook and inferenceNotebook may be part of request body
since Jupyter files are just regular JSON files. This fix handles
when someone sends them in body for POST/PATCH requests.
Adds/Fix unit tests

- Ensures MinIO bucket exists for get_object calls

Calls make_bucket before get_object. This is especially useful to
avoid errors in GET /components