### PR TITLE
Set experiment_id and operator_id when creating components

### DIFF
--- a/projects/jupyter.py
+++ b/projects/jupyter.py
@@ -44,7 +44,7 @@ def create_new_file(path, is_folder, content=None):
     Args:
         path (str): path to the file or folder.
         is_folder (bool): whether to create a file or a folder.
-        content (bool, optional): the file content.
+        content (bytes, optional): the file content.
     """
     if content is not None:
         content = loads(content.decode("utf-8"))

--- a/projects/object_storage.py
+++ b/projects/object_storage.py
@@ -33,6 +33,9 @@ def get_object(source):
 
     Args:
         source (str): the path to source object.
+
+    Returns:
+        bytes: the file contents as bytes.
     """
     # ensures MinIO bucket exists
     make_bucket(BUCKET_NAME)


### PR DESCRIPTION
PlatIAgro notebooks have experiment_id and operator_id in their
metadata to interact with PlatIAgro SDK functions.
Newly created components were copying the metadata from other
components, which may cause unexpected behavior.

experiment_id and operator_id are now randomized and set during
creation step.