### PR TITLE
Calls pipeline.transform() before automl.refit()

### DIFF
--- a/samples/automl-classifier/Training.ipynb
+++ b/samples/automl-classifier/Training.ipynb
@@ -213,6 +213,7 @@
     "])\n",
     "\n",
     "pipeline.fit(X_train, y_train)\n",
+    "X_train = Pipeline(pipeline.steps[:-1]).transform(X_train)\n",
     "pipeline.named_steps.estimator.refit(X_train, y_train)"
    ]
   },

--- a/samples/automl-regressor/Training.ipynb
+++ b/samples/automl-regressor/Training.ipynb
@@ -211,6 +211,7 @@
     "])\n",
     "\n",
     "pipeline.fit(X_train, y_train)\n",
+    "X_train = Pipeline(pipeline.steps[:-1]).transform(X_train)\n",
     "pipeline.named_steps.estimator.refit(X_train, y_train)"
    ]
   },


### PR DESCRIPTION
Refit requires data to be preprocessed, just like automl.fit().
Not doing so causes errors like this:
ValueError: could not convert string to float: '2016-10-08'