### PR TITLE
Fix ftools pd_todatetime by changing datetime type to str.

### DIFF
--- a/samples/feature-tools/Experiment.ipynb
+++ b/samples/feature-tools/Experiment.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget !wget https://raw.githubusercontent.com/platiagro/projects/master/samples/feature-tools/ftools.py"
+    "!wget https://raw.githubusercontent.com/platiagro/projects/master/samples/feature-tools/ftools.py"
    ]
   },
   {

--- a/samples/feature-tools/ftools.py
+++ b/samples/feature-tools/ftools.py
@@ -36,7 +36,8 @@ class FeatureTools():
         self.names = names
 
         if date_var is not None:
-            self.data[date_var] = pd.to_datetime(self.data[date_var])
+            self.data[date_var] = self.data[date_var].astype(str)
+            self.data[date_var] = pd.to_datetime(self.data[date_var], infer_datetime_format=True)
 
         warnings.filterwarnings("ignore")
 


### PR DESCRIPTION
Removed !wget duplicated and put datetime convert to str so that a "ValueError: to assemble mappings requires at least that [year, month, day] be specified: [day,month,year] is missing" doesn't happen. Also added infer_format... = True.