### PR TITLE
Added Papermill Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ extras = {
         "pytest-xdist==1.31.0",
         "pytest-cov==2.8.1",
         "flake8==3.7.9",
+        "papermill[s3]==2.1.1"
     ]
 }
 


### PR DESCRIPTION
Papermill dependecy isn't in setup.py's extras.
It's necessary for tests.