### PR TITLE
Removes 'save_figure' from notebooks

### DIFF
--- a/projects/config/Deployment.ipynb
+++ b/projects/config/Deployment.ipynb
@@ -111,7 +111,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "a06562ac-4f6e-4f41-a764-37dec7ed93d3",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -127,9 +127,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  },
-  "operator_id": "d698239e-b3b9-4a38-9b3b-985a3bbe0bf3"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/projects/config/Experiment.ipynb
+++ b/projects/config/Experiment.ipynb
@@ -151,26 +151,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from platiagro import save_figures\n",
-    "\n",
-    "save_figures(figure=matplotfig)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Salva modelo e outros artefatos\n",
     "\n",
     "Utiliza a função `save_model` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar modelos e outros artefatos.<br>\n",
@@ -191,7 +171,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "a06562ac-4f6e-4f41-a764-37dec7ed93d3",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -207,9 +186,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  },
-  "operator_id": "d698239e-b3b9-4a38-9b3b-985a3bbe0bf3"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/README.md
+++ b/samples/README.md
@@ -5,7 +5,13 @@
     └── automl-regressor
     │   ├── Experiment.ipynb
     │   └── Deployment.ipynb
+    └── descriptive-analysis
+    |   ├── Experiment.ipynb
+    |   └── Deployment.ipynb
     └── filter-selection
+    |   ├── Experiment.ipynb
+    |   └── Deployment.ipynb
+    └── grouping-categorical-features
     |   ├── Experiment.ipynb
     |   └── Deployment.ipynb
     └── kmeans-clustering
@@ -28,16 +34,31 @@
     │   └── Deployment.ipynb
     └── pre-selection
     |   ├── Experiment.ipynb
-    |   └── Deployment.ipynb 
+    |   └── Deployment.ipynb
     └── random-forest-classifier
     │   ├── Experiment.ipynb
     │   └── Deployment.ipynb
     └── random-forest-regressor
     │   ├── Experiment.ipynb
     │   └── Deployment.ipynb
+    └── rfe-selector
+    │   ├── Experiment.ipynb
+    │   └── Deployment.ipynb
+    └── robust-scaler
+    │   ├── Experiment.ipynb
+    │   └── Deployment.ipynb
+    └── simulated-annealing
+    │   ├── Experiment.ipynb
+    │   └── Deployment.ipynb
     └── svc
     │   ├── Experiment.ipynb
     │   └── Deployment.ipynb
     └── svr
+    │   ├── Experiment.ipynb
+    │   └── Deployment.ipynb
+    └── transformation-graph
+    │   ├── Experiment.ipynb
+    │   └── Deployment.ipynb
+    └── variance-threshold
         ├── Experiment.ipynb
         └── Deployment.ipynb

--- a/samples/automl-classifier/Deployment.ipynb
+++ b/samples/automl-classifier/Deployment.ipynb
@@ -165,7 +165,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "48f2668a-e31a-4b5a-a91a-28fd649f7adc",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -181,9 +181,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "64401802-2785-4f26-85c8-d7974fc78454"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/automl-classifier/Experiment.ipynb
+++ b/samples/automl-classifier/Experiment.ipynb
@@ -373,9 +373,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html). <br>\n",
+    "## Visualiza resultados\n",
     "\n",
     "A avaliação do desempenho do modelo pode ser feita por meio da análise da [Curva ROC (ROC)](https://pt.wikipedia.org/wiki/Caracter%C3%ADstica_de_Opera%C3%A7%C3%A3o_do_Receptor).  Esse gráfico permite avaliar a performance de um classificador binário para diferentes pontos de cortes. A métrica [AUC (Area under curve)](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) também é calculada e indicada na legenda do gráfico.<br>\n",
     "Se a variável resposta tiver mais de duas categorias, o cálculo da curva ROC e AUC é feito utilizando o algoritmo [one-vs-rest](https://scikit-learn.org/stable/modules/model_evaluation.html#roc-metrics), ou seja, calcula-se a curva ROC e AUC de cada classe em relação ao restante."
@@ -388,8 +386,6 @@
    "outputs": [],
    "source": [
     "from matplotlib.pyplot import cm\n",
-    "from platiagro import save_figure\n",
-    "from platiagro import list_figures\n",
     "from sklearn.metrics import roc_curve, auc\n",
     "from sklearn import preprocessing\n",
     "import matplotlib.pyplot as plt\n",
@@ -417,7 +413,6 @@
     "        plt.ylabel('True Positive Rate')\n",
     "        plt.title('ROC Curve')\n",
     "        plt.legend(loc=\"lower right\")\n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "        \n",
     "    else:  \n",
@@ -448,8 +443,7 @@
     "             lw=lw, label='ROC curve - Class %s (area = %0.2f)' % (labels[i] ,roc_auc[i]))\n",
     "            plt.title('ROC Curve One-vs-Rest')\n",
     "            plt.legend(loc=\"lower right\")\n",
-    "        \n",
-    "        save_figure(figure=plt.gcf())\n",
+    "\n",
     "        plt.show()\n",
     "\n",
     "plot_roc_curve(y_test,y_prob,labels)"
@@ -517,7 +511,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "48f2668a-e31a-4b5a-a91a-28fd649f7adc",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -533,9 +526,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "64401802-2785-4f26-85c8-d7974fc78454"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/automl-regressor/Deployment.ipynb
+++ b/samples/automl-regressor/Deployment.ipynb
@@ -203,7 +203,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "6db0fff7-ba9d-4f64-8cbe-9a31bd8b3644",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -219,9 +219,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "1fbe7220-0b4b-4eb6-aba2-b8afec49250d"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/automl-regressor/Experiment.ipynb
+++ b/samples/automl-regressor/Experiment.ipynb
@@ -307,9 +307,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html)."
+    "## Visualiza resultados"
    ]
   },
   {
@@ -319,7 +317,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from platiagro import save_figure\n",
     "from scipy.stats import gaussian_kde\n",
     "\n",
     "\n",
@@ -400,9 +397,7 @@
     "annotate_plot(aux, 95, plt, y_lim, 1.2, abs_err)\n",
     "\n",
     "plt.grid(True)\n",
-    "plt.title(\"Error Distribution\")\n",
-    "\n",
-    "save_figure(figure=plt.gcf())"
+    "plt.title(\"Error Distribution\")"
    ]
   },
   {
@@ -457,7 +452,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "6db0fff7-ba9d-4f64-8cbe-9a31bd8b3644",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -473,9 +467,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "1fbe7220-0b4b-4eb6-aba2-b8afec49250d"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/config.json
+++ b/samples/config.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "AutoML Classifier",
+        "name": "Classificador AutoML",
         "description": "Utiliza o auto-sklearn para obter um ou mais modelos classificadores já otimizados",
         "experimentNotebook": "/samples/automl-classifier/Experiment.ipynb",
         "deploymentNotebook": "/samples/automl-classifier/Deployment.ipynb",
@@ -9,7 +9,7 @@
         ]
     },
     {
-        "name": "AutoML Regressor",
+        "name": "Regressor AutoML",
         "description": "Utiliza o auto-sklearn para obter um ou mais modelos regressores já otimizados",
         "experimentNotebook": "/samples/automl-regressor/Experiment.ipynb",
         "deploymentNotebook": "/samples/automl-regressor/Deployment.ipynb",
@@ -18,7 +18,7 @@
         ]
     },
     {
-        "name": "Linear Regression",
+        "name": "Regressão Linear",
         "description": "Treina um modelo de Regressão Linear para regressão usando scikit-learn",
         "experimentNotebook": "/samples/linear-regression/Experiment.ipynb",
         "deploymentNotebook": "/samples/linear-regression/Deployment.ipynb",
@@ -27,7 +27,7 @@
         ]
     },
     {
-        "name": "Logistic Regression",
+        "name": "Regressão Logística",
         "description": "Treina um modelo de Regressão Logística para classificação usando scikit-learn",
         "experimentNotebook": "/samples/logistic-regression/Experiment.ipynb",
         "deploymentNotebook": "/samples/logistic-regression/Deployment.ipynb",
@@ -36,7 +36,7 @@
         ]
     },
     {
-        "name": "MLP Classifier",
+        "name": "Classificador MLP",
         "description": "Treina um modelo classificador Multi-layer Perceptron (MLP) usando scikit-learn",
         "experimentNotebook": "/samples/mlp-classifier/Experiment.ipynb",
         "deploymentNotebook": "/samples/mlp-classifier/Deployment.ipynb",
@@ -45,7 +45,7 @@
         ]
     },
     {
-        "name": "MLP Regressor",
+        "name": "Regressor MLP",
         "description": "Treina um modelo regressor Multi-layer Perceptron (MLP) usando scikit-learn",
         "experimentNotebook": "/samples/mlp-regressor/Experiment.ipynb",
         "deploymentNotebook": "/samples/mlp-regressor/Deployment.ipynb",
@@ -54,7 +54,7 @@
         ]
     },
     {
-        "name": "Random Forest Classifier",
+        "name": "Classificador Random Forest",
         "description": "Treina um modelo classificador Random Forest usando scikit-learn",
         "experimentNotebook": "/samples/random-forest-classifier/Experiment.ipynb",
         "deploymentNotebook": "/samples/random-forest-classifier/Deployment.ipynb",
@@ -63,7 +63,7 @@
         ]
     },
     {
-        "name": "Random Forest Regressor",
+        "name": "Regressor Random Forest",
         "description": "Treina um modelo regressor Random Forest usando scikit-learn",
         "experimentNotebook": "/samples/random-forest-regressor/Experiment.ipynb",
         "deploymentNotebook": "/samples/random-forest-regressor/Deployment.ipynb",
@@ -72,7 +72,7 @@
         ]
     },
     {
-        "name": "SVC",
+        "name": "Classificador SVM",
         "description": "Treina um modelo Support Vector Classification usando scikit-learn",
         "experimentNotebook": "/samples/svc/Experiment.ipynb",
         "deploymentNotebook": "/samples/svc/Deployment.ipynb",
@@ -81,7 +81,7 @@
         ]
     },
     {
-        "name": "SVR",
+        "name": "Regressor SVM",
         "description": "Treina um modelo Support Vector Regression usando scikit-learn",
         "experimentNotebook": "/samples/svr/Experiment.ipynb",
         "deploymentNotebook": "/samples/svr/Deployment.ipynb",
@@ -90,7 +90,7 @@
         ]
     },
     {
-        "name": "KMeans",
+        "name": "Clusterização KMeans",
         "description": "Treina um modelo KMeans para clusterização usando scikit-learn",
         "experimentNotebook": "/samples/kmeans-clustering/Experiment.ipynb",
         "deploymentNotebook": "/samples/kmeans-clustering/Deployment.ipynb",
@@ -99,7 +99,7 @@
         ]
     },
     {
-        "name": "Isolation Forest",
+        "name": "Detecção de Anomalias por Isolation Forest",
         "description": "Treina um modelo Isolation Forest para detecção de anomalias usando scikit-learn",
         "experimentNotebook": "/samples/isolation-forest-clustering/Experiment.ipynb",
         "deploymentNotebook": "/samples/isolation-forest-clustering/Deployment.ipynb",
@@ -108,7 +108,7 @@
         ]
     },
     {
-        "name": "Normalizer",
+        "name": "Normalizador de Amostras",
         "description": "Normaliza amostras individualmente para o modelo de norma de unidade usando scikit-learn",
         "experimentNotebook": "/samples/normalizer/Experiment.ipynb",
         "deploymentNotebook": "/samples/normalizer/Deployment.ipynb",
@@ -117,7 +117,7 @@
         ]
     },
     {
-        "name": "Imputer",
+        "name": "Imputação de Valores Faltantes",
         "description": "Imputa valores ausentes usando média, mediana ou mais frequente",
         "experimentNotebook": "/samples/imputer/Experiment.ipynb",
         "deploymentNotebook": "/samples/imputer/Deployment.ipynb",
@@ -126,8 +126,8 @@
         ]
     },
     {
-        "name": "Variance Threshold",
-        "description": "Remove todos os recursos de baixa variação",
+        "name": "Seleção de Atributos por Limiar de Variância",
+        "description": "Remove todos os atributos de baixa variância",
         "experimentNotebook": "/samples/variance-threshold/Experiment.ipynb",
         "deploymentNotebook": "/samples/variance-threshold/Deployment.ipynb",
         "tags": [
@@ -135,7 +135,7 @@
         ]
     },
     {
-        "name": "Robust Scaler",
+        "name": "Scaler Robusto",
         "description": "Dimensiona features usando estatísticas robustas para outliers",
         "experimentNotebook": "/samples/robust-scaler/Experiment.ipynb",
         "deploymentNotebook": "/samples/robust-scaler/Deployment.ipynb",
@@ -153,7 +153,7 @@
         ]
     },
     {
-        "name": "Pre Selection",
+        "name": "Seleção de Atributos por Correlação",
         "description": "Remove todas as features de baixa variação e altamente correlacionadas",
         "experimentNotebook": "/samples/pre-selection/Experiment.ipynb",
         "deploymentNotebook": "/samples/pre-selection/Deployment.ipynb",
@@ -180,7 +180,7 @@
         ]
     },
     {
-        "name": "Filter Selection",
+        "name": "Seleção Manual de Atributos",
         "description": "Remove as features específicas do conjunto de dados",
         "experimentNotebook": "/samples/filter-selection/Experiment.ipynb",
         "deploymentNotebook": "/samples/filter-selection/Deployment.ipynb",
@@ -189,7 +189,7 @@
         ]
     },
     {
-        "name": "Recursive Feature Elimination",
+        "name": "Seleção de Atributos por Método de Eliminação Recursiva",
         "description": "Realiza a seleção de features baseado no método de eliminação recursiva usando um estimador Random Forest",
         "experimentNotebook": "/samples/rfe-selector/Experiment.ipynb",
         "deploymentNotebook": "/samples/rfe-selector/Deployment.ipynb",
@@ -198,7 +198,7 @@
         ]
     },
     {
-        "name": "Descriptive Analysis",
+        "name": "Análise Descritiva",
         "description": "Gera estatísticas descritivas para um determinado conjunto de dados",
         "experimentNotebook": "/samples/descriptive-analysis/Experiment.ipynb",
         "tags": [
@@ -206,15 +206,15 @@
         ]
     },
 		{
-        "name": "Conjunto de dados",
-        "description": "Conjunto de dados",
+        "name": "Conjunto de Dados",
+        "description": "Importa arquivos para utilização em experimentos.",
         "experimentNotebook": "/samples/datasets/Experiment.ipynb",
         "tags": [
             "DATASETS"
         ]
     },
 	    {
-        "name": "Grouping High Cardinality Features",
+        "name": "Agrupamento de Atributos Categóricos",
         "description": "Faz o agrupamento de features categóricas com elevado número de classes",
         "experimentNotebook": "/samples/grouping-categorical-features/Experiment.ipynb",
         "tags": [

--- a/samples/datasets/Experiment.ipynb
+++ b/samples/datasets/Experiment.ipynb
@@ -24,7 +24,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/samples/descriptive-analysis/Experiment.ipynb
+++ b/samples/descriptive-analysis/Experiment.ipynb
@@ -103,7 +103,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from platiagro import save_figure\n",
     "\n",
     "def format_str_cell(text, max_len=20):\n",
     "    return text[:max_len] + '...' if len(text) > max_len else text\n",
@@ -142,19 +141,16 @@
     "\n",
     "if categorical_description is not None:\n",
     "    render_table(categorical_description, header_columns=0, col_width=2.0)\n",
-    "    save_figure(figure=plt.gcf())\n",
-    "    plt.clf()\n",
+    "    plt.show()\n",
     "\n",
     "if numeric_description is not None:\n",
     "    render_table(numeric_description, header_columns=0, col_width=2.0)\n",
-    "    save_figure(figure=plt.gcf())\n",
-    "    plt.clf()"
+    "    plt.show()"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "ef459489-8284-4f43-9ee0-c60ca529878a",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -170,9 +166,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "f46ebbfe-a615-425a-99a9-2b48e2b7ff5b"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/feature-tools/Deployment.ipynb
+++ b/samples/feature-tools/Deployment.ipynb
@@ -283,7 +283,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "d665a4d9-5775-4666-b246-a687343ff8ea",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -299,10 +299,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "4be2ce04-7919-44f9-a700-a7d9819e7fe0"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/feature-tools/Experiment.ipynb
+++ b/samples/feature-tools/Experiment.ipynb
@@ -170,7 +170,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "d665a4d9-5775-4666-b246-a687343ff8ea",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -186,9 +185,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "4be2ce04-7919-44f9-a700-a7d9819e7fe0"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/filter-selection/Deployment.ipynb
+++ b/samples/filter-selection/Deployment.ipynb
@@ -153,7 +153,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "baa4dfa2-9ebb-11ea-bb37-0242ac130002",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -169,9 +169,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "c2dc16f4-9ebb-11ea-bb37-0242ac130002"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/filter-selection/Experiment.ipynb
+++ b/samples/filter-selection/Experiment.ipynb
@@ -141,7 +141,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "baa4dfa2-9ebb-11ea-bb37-0242ac130002",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -157,9 +156,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "c2dc16f4-9ebb-11ea-bb37-0242ac130002"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/grouping-categorical-features/Deployment.ipynb
+++ b/samples/grouping-categorical-features/Deployment.ipynb
@@ -256,7 +256,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "b54d542d-6a61-4162-adf5-bf5321cd9a65",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -272,9 +272,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "aa4931ba-b95d-4507-897d-c58f322be9db"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/grouping-categorical-features/Experiment.ipynb
+++ b/samples/grouping-categorical-features/Experiment.ipynb
@@ -265,7 +265,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "b54d542d-6a61-4162-adf5-bf5321cd9a65",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -281,9 +280,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "aa4931ba-b95d-4507-897d-c58f322be9db"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/imputer/Deployment.ipynb
+++ b/samples/imputer/Deployment.ipynb
@@ -161,7 +161,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "ab814fda-ef4a-4cc6-9d83-a050094fb5aa",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -177,9 +176,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "b8719065-0e88-4198-9635-33a3832f90e4"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/imputer/Experiment.ipynb
+++ b/samples/imputer/Experiment.ipynb
@@ -201,7 +201,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "ab814fda-ef4a-4cc6-9d83-a050094fb5aa",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -217,9 +216,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "b8719065-0e88-4198-9635-33a3832f90e4"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/isolation-forest-clustering/Deployment.ipynb
+++ b/samples/isolation-forest-clustering/Deployment.ipynb
@@ -152,7 +152,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "8ab3a539-cf46-458b-8747-224ed6c75d84",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -168,9 +167,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "18566747-2d0d-4d14-acb2-514bd1f91d43"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/isolation-forest-clustering/Experiment.ipynb
+++ b/samples/isolation-forest-clustering/Experiment.ipynb
@@ -218,13 +218,10 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
-    "from platiagro import save_figure\n",
     "\n",
     "ax = sns.scatterplot(x=\"X\", y=\"Y\", hue=\"Anomaly\", data=X_pca)\n",
     "\n",
-    "ax.set_title(\"PCA Graph\", {\"fontweight\": 'bold'})\n",
-    "\n",
-    "save_figure(figure=plt.gcf())"
+    "ax.set_title(\"PCA Graph\", {\"fontweight\": 'bold'})"
    ]
   },
   {
@@ -299,7 +296,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "8ab3a539-cf46-458b-8747-224ed6c75d84",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -315,9 +311,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "18566747-2d0d-4d14-acb2-514bd1f91d43"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/kmeans-clustering/Deployment.ipynb
+++ b/samples/kmeans-clustering/Deployment.ipynb
@@ -152,7 +152,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "da9c61f2-fd3f-4ba1-8f72-f47e81e83d6c",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -168,9 +168,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "cd73629b-a548-4f10-8abc-22fe328aa3c9"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/kmeans-clustering/Experiment.ipynb
+++ b/samples/kmeans-clustering/Experiment.ipynb
@@ -204,7 +204,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from platiagro import save_figure\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
     "\n",
@@ -212,9 +211,7 @@
     "\n",
     "ax.set_title(\"PCA Graph\", {\"fontweight\": \"bold\"})\n",
     "\n",
-    "plt.grid(True)\n",
-    "\n",
-    "save_figure(figure=plt.gcf())"
+    "plt.grid(True)"
    ]
   },
   {
@@ -288,7 +285,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "da9c61f2-fd3f-4ba1-8f72-f47e81e83d6c",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -304,9 +300,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "cd73629b-a548-4f10-8abc-22fe328aa3c9"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/linear-regression/Deployment.ipynb
+++ b/samples/linear-regression/Deployment.ipynb
@@ -203,7 +203,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -219,9 +219,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "0d7db969-c4dc-467b-8a62-a7207b1735eb"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/linear-regression/Experiment.ipynb
+++ b/samples/linear-regression/Experiment.ipynb
@@ -299,9 +299,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html)."
+    "## Visualiza resultados"
    ]
   },
   {
@@ -311,7 +309,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from platiagro import save_figure\n",
     "from scipy.stats import gaussian_kde\n",
     "\n",
     "\n",
@@ -392,9 +389,7 @@
     "annotate_plot(aux, 95, plt, y_lim, 1.2, abs_err)\n",
     "\n",
     "plt.grid(True)\n",
-    "plt.title(\"Error Distribution\")\n",
-    "\n",
-    "save_figure(figure=plt.gcf())"
+    "plt.title(\"Error Distribution\")"
    ]
   },
   {
@@ -451,7 +446,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -467,9 +461,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "2a67f397-8b0e-4fa7-8d29-438f1f6f447a"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/logistic-regression/Deployment.ipynb
+++ b/samples/logistic-regression/Deployment.ipynb
@@ -165,7 +165,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "7315b5a1-0692-4711-921d-5570f28c2a76",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -181,9 +180,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "07091821-9548-410f-a359-9266c9c75c79"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/logistic-regression/Experiment.ipynb
+++ b/samples/logistic-regression/Experiment.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "# parameters\n",
-    "dataset = \"/tmp/data/iris.csv\" # Dataset recebido através da plataforma\n",
+    "dataset = \"/tmp/data/iris.csv\" #@param {type:\"string\"}\n",
     "target = \"Species\" #@param {type:\"feature\", label:\"Atributo alvo\", description: \"Seu modelo será treinado para prever os valores do alvo.\"}\n",
     "\n",
     "# selected features to perform the model\n",
@@ -379,9 +379,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html). <br>\n",
+    "## Visualiza resultados\n",
     "\n",
     "A avaliação do desempenho do modelo pode ser feita por meio da análise da [Curva ROC (ROC)](https://pt.wikipedia.org/wiki/Caracter%C3%ADstica_de_Opera%C3%A7%C3%A3o_do_Receptor). Esse gráfico permite avaliar a performance de um classificador binário para diferentes pontos de cortes. A métrica [AUC (Area under curve)](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) também é calculada e indicada na legenda do gráfico.\n",
     "Se a variável resposta tiver mais de duas categorias, o cálculo da curva ROC e AUC é feito utilizando o algoritmo [one-vs-rest](https://scikit-learn.org/stable/modules/model_evaluation.html#roc-metrics), ou seja, calcula-se a curva ROC e AUC de cada classe em relação ao restante."
@@ -394,8 +392,6 @@
    "outputs": [],
    "source": [
     "from matplotlib.pyplot import cm\n",
-    "from platiagro import save_figure\n",
-    "from platiagro import list_figures\n",
     "from sklearn.metrics import roc_curve, auc\n",
     "from sklearn import preprocessing\n",
     "import matplotlib.pyplot as plt\n",
@@ -423,7 +419,6 @@
     "        plt.ylabel('True Positive Rate')\n",
     "        plt.title('ROC Curve')\n",
     "        plt.legend(loc=\"lower right\")\n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "        \n",
     "    else:  \n",
@@ -455,7 +450,6 @@
     "            plt.title('ROC Curve One-vs-Rest')\n",
     "            plt.legend(loc=\"lower right\")\n",
     "        \n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "\n",
     "plot_roc_curve(y_test,y_prob,labels)"
@@ -523,7 +517,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "7315b5a1-0692-4711-921d-5570f28c2a76",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -539,9 +532,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "07091821-9548-410f-a359-9266c9c75c79"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/mlp-classifier/Deployment.ipynb
+++ b/samples/mlp-classifier/Deployment.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Multi-layer Perceptron Classifier - Implantação\n",
+    "# Classificador Multi-layer Perceptron - Implantação\n",
     "\n",
     "Este componente realiza predições usando um modelo Multi-layer Perceptron para classificação usando [Scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPClassifier.html). <br>\n",
     "Scikit-learn é uma biblioteca open source de machine learning que suporta apredizado supervisionado e não supervisionado. Também provê várias ferramentas para ajustes de modelos, pré-processamento de dados, seleção e avaliação de modelos, além de outras funcionalidades.\n",
@@ -165,7 +165,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "0805394e-f07f-4b29-ba88-bc46ab074eba",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -181,9 +180,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "bbc2a87c-4970-4de4-9920-2f385e91f9a3"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/mlp-classifier/Experiment.ipynb
+++ b/samples/mlp-classifier/Experiment.ipynb
@@ -376,10 +376,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html). <br>\n",
-    "\n",
+    "## Visualiza resultados\n",
     "A avaliação do desempenho do modelo pode ser feita por meio da análise da [Curva ROC (ROC)](https://pt.wikipedia.org/wiki/Caracter%C3%ADstica_de_Opera%C3%A7%C3%A3o_do_Receptor).  Esse gráfico permite avaliar a performance de um classificador binário para diferentes pontos de cortes. A métrica [AUC (Area under curve)](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) também é calculada e indicada na legenda do gráfico.<br>\n",
     "Se a variável resposta tiver mais de duas categorias, o cálculo da curva ROC e AUC é feito utilizando o algoritmo [one-vs-rest](https://scikit-learn.org/stable/modules/model_evaluation.html#roc-metrics), ou seja, calcula-se a curva ROC e AUC de cada classe em relação ao restante."
    ]
@@ -391,8 +388,6 @@
    "outputs": [],
    "source": [
     "from matplotlib.pyplot import cm\n",
-    "from platiagro import save_figure\n",
-    "from platiagro import list_figures\n",
     "from sklearn.metrics import roc_curve, auc\n",
     "from sklearn import preprocessing\n",
     "import matplotlib.pyplot as plt\n",
@@ -420,7 +415,6 @@
     "        plt.ylabel('True Positive Rate')\n",
     "        plt.title('ROC Curve')\n",
     "        plt.legend(loc=\"lower right\")\n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "        \n",
     "    else:  \n",
@@ -451,8 +445,7 @@
     "             lw=lw, label='ROC curve - Class %s (area = %0.2f)' % (labels[i] ,roc_auc[i]))\n",
     "            plt.title('ROC Curve One-vs-Rest')\n",
     "            plt.legend(loc=\"lower right\")\n",
-    "        \n",
-    "        save_figure(figure=plt.gcf())\n",
+    "\n",
     "        plt.show()\n",
     "\n",
     "plot_roc_curve(y_test,y_prob,labels)"
@@ -520,7 +513,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "0805394e-f07f-4b29-ba88-bc46ab074eba",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -536,9 +528,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "bbc2a87c-4970-4de4-9920-2f385e91f9a3"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/mlp-regressor/Deployment.ipynb
+++ b/samples/mlp-regressor/Deployment.ipynb
@@ -203,7 +203,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -219,9 +218,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "2a67f397-8b0e-4fa7-8d29-438f1f6f447a"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/mlp-regressor/Experiment.ipynb
+++ b/samples/mlp-regressor/Experiment.ipynb
@@ -313,9 +313,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html)."
+    "## Visualiza resultados"
    ]
   },
   {
@@ -325,7 +323,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from platiagro import save_figure\n",
     "from scipy.stats import gaussian_kde\n",
     "\n",
     "\n",
@@ -406,9 +403,7 @@
     "annotate_plot(aux, 95, plt, y_lim, 1.2, abs_err)\n",
     "\n",
     "plt.grid(True)\n",
-    "plt.title(\"Error Distribution\")\n",
-    "\n",
-    "save_figure(figure=plt.gcf())"
+    "plt.title(\"Error Distribution\")"
    ]
   },
   {
@@ -463,7 +458,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "bed7a0e4-27fb-4be2-9f22-7861d15962df",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -479,9 +473,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "2a67f397-8b0e-4fa7-8d29-438f1f6f447a"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/normalizer/Deployment.ipynb
+++ b/samples/normalizer/Deployment.ipynb
@@ -162,7 +162,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "ccbd7c54-cbd4-4b1f-95ab-1943f119b71e",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -178,9 +178,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "fbf7d573-d6fd-4a0e-9033-6930248948be"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/normalizer/Experiment.ipynb
+++ b/samples/normalizer/Experiment.ipynb
@@ -204,7 +204,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "ccbd7c54-cbd4-4b1f-95ab-1943f119b71e",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -220,9 +219,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "fbf7d573-d6fd-4a0e-9033-6930248948be"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/pre-selection/Deployment.ipynb
+++ b/samples/pre-selection/Deployment.ipynb
@@ -174,7 +174,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "94c3e6b9-0420-4d48-a5df-2d31fc2ad3af",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -190,9 +190,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  },
-  "operator_id": "a43611a0-3d85-4bee-b94a-4ab7b01e9e21"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/pre-selection/Experiment.ipynb
+++ b/samples/pre-selection/Experiment.ipynb
@@ -248,7 +248,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "94c3e6b9-0420-4d48-a5df-2d31fc2ad3af",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -264,9 +263,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  },
-  "operator_id": "a43611a0-3d85-4bee-b94a-4ab7b01e9e21"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/random-forest-classifier/Deployment.ipynb
+++ b/samples/random-forest-classifier/Deployment.ipynb
@@ -165,7 +165,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "08d03e85-4a7c-4376-873c-5828ea603e1f",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -181,9 +181,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "8df0c5c7-10d7-4150-8c62-f51ae2550bf2"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/random-forest-classifier/Experiment.ipynb
+++ b/samples/random-forest-classifier/Experiment.ipynb
@@ -379,9 +379,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html). <br>\n",
+    "## Visualiza resultados\n",
     "\n",
     "A avaliação do desempenho do modelo pode ser feita por meio da análise da [Curva ROC (ROC)](https://pt.wikipedia.org/wiki/Caracter%C3%ADstica_de_Opera%C3%A7%C3%A3o_do_Receptor).  Esse gráfico permite avaliar a performance de um classificador binário para diferentes pontos de cortes. A métrica [AUC (Area under curve)](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) também é calculada e indicada na legenda do gráfico.<br>\n",
     "Se a variável resposta tiver mais de duas categorias, o cálculo da curva ROC e AUC é feito utilizando o algoritmo [one-vs-rest](https://scikit-learn.org/stable/modules/model_evaluation.html#roc-metrics), ou seja, calcula-se a curva ROC e AUC de cada classe em relação ao restante."
@@ -394,8 +392,6 @@
    "outputs": [],
    "source": [
     "from matplotlib.pyplot import cm\n",
-    "from platiagro import save_figure\n",
-    "from platiagro import list_figures\n",
     "from sklearn.metrics import roc_curve, auc\n",
     "from sklearn import preprocessing\n",
     "import matplotlib.pyplot as plt\n",
@@ -422,7 +418,6 @@
     "        plt.ylabel('True Positive Rate')\n",
     "        plt.title('ROC Curve')\n",
     "        plt.legend(loc=\"lower right\")\n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "        \n",
     "    else:  \n",
@@ -454,7 +449,6 @@
     "            plt.title('ROC Curve One-vs-Rest')\n",
     "            plt.legend(loc=\"lower right\")\n",
     "        \n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "\n",
     "plot_roc_curve(y_test,y_prob,labels)"
@@ -522,7 +516,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "08d03e85-4a7c-4376-873c-5828ea603e1f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -538,9 +531,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "8df0c5c7-10d7-4150-8c62-f51ae2550bf2"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/random-forest-regressor/Deployment.ipynb
+++ b/samples/random-forest-regressor/Deployment.ipynb
@@ -203,7 +203,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "d4269baf-e917-4c94-b078-7dc0223a6a1f",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -219,9 +219,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "d150e465-f3d5-422d-92e6-409eefe0e399"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/random-forest-regressor/Experiment.ipynb
+++ b/samples/random-forest-regressor/Experiment.ipynb
@@ -309,9 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html)."
+    "## Visualiza resultados"
    ]
   },
   {
@@ -321,7 +319,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from platiagro import save_figure\n",
     "from scipy.stats import gaussian_kde\n",
     "\n",
     "\n",
@@ -402,9 +399,7 @@
     "annotate_plot(aux, 95, plt, y_lim, 1.2, abs_err)\n",
     "\n",
     "plt.grid(True)\n",
-    "plt.title(\"Error Distribution\")\n",
-    "\n",
-    "save_figure(figure=plt.gcf())"
+    "plt.title(\"Error Distribution\")"
    ]
   },
   {
@@ -459,7 +454,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "d4269baf-e917-4c94-b078-7dc0223a6a1f",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -475,9 +469,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "d150e465-f3d5-422d-92e6-409eefe0e399"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/rfe-selector/Deployment.ipynb
+++ b/samples/rfe-selector/Deployment.ipynb
@@ -188,7 +188,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "bc989dca-2568-413d-9c06-b165a1a85fc1",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -204,9 +203,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "e229a081-7b87-4c25-99b0-160d9824eff9"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/rfe-selector/Experiment.ipynb
+++ b/samples/rfe-selector/Experiment.ipynb
@@ -229,7 +229,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "bc989dca-2568-413d-9c06-b165a1a85fc1",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -245,9 +244,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "e229a081-7b87-4c25-99b0-160d9824eff9"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/robust-scaler/Deployment.ipynb
+++ b/samples/robust-scaler/Deployment.ipynb
@@ -163,7 +163,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "a44326ab-b552-4218-b691-acef3e93f53a",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -179,9 +179,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "e37dbfc0-f9cc-4a83-bbfc-6d740a8f3c75"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/robust-scaler/Experiment.ipynb
+++ b/samples/robust-scaler/Experiment.ipynb
@@ -206,7 +206,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "a44326ab-b552-4218-b691-acef3e93f53a",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -222,9 +221,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "e37dbfc0-f9cc-4a83-bbfc-6d740a8f3c75"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/simulated-annealing/Deployment.ipynb
+++ b/samples/simulated-annealing/Deployment.ipynb
@@ -279,7 +279,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "d025813c-7348-4e4c-8f1a-f812f6793a09",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -295,9 +294,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "84cfc55c-8f6e-4bc0-8210-f42989fe8cbf"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/samples/simulated-annealing/Experiment.ipynb
+++ b/samples/simulated-annealing/Experiment.ipynb
@@ -177,7 +177,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "d025813c-7348-4e4c-8f1a-f812f6793a09",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -193,9 +192,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "84cfc55c-8f6e-4bc0-8210-f42989fe8cbf"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/svc/Deployment.ipynb
+++ b/samples/svc/Deployment.ipynb
@@ -165,7 +165,6 @@
   }
  ],
  "metadata": {
-  "experiment_id": "1550eac4-931b-41f1-bf58-a958b2249620",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -181,9 +180,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "c0deb81a-540e-4d51-bf8f-c332f9b9fd73"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/svc/Experiment.ipynb
+++ b/samples/svc/Experiment.ipynb
@@ -380,9 +380,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html). <br>\n",
+    "## Visualiza resultados\n",
     "\n",
     "A avaliação do desempenho do modelo pode ser feita por meio da análise da [Curva ROC (ROC)](https://pt.wikipedia.org/wiki/Caracter%C3%ADstica_de_Opera%C3%A7%C3%A3o_do_Receptor).  Esse gráfico permite avaliar a performance de um classificador binário para diferentes pontos de cortes. A métrica [AUC (Area under curve)](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve) também é calculada e indicada na legenda do gráfico.<br>\n",
     "Se a variável resposta tiver mais de duas categorias, o cálculo da curva ROC e AUC é feito utilizando o algoritmo [one-vs-rest](https://scikit-learn.org/stable/modules/model_evaluation.html#roc-metrics), ou seja, calcula-se a curva ROC e AUC de cada classe em relação ao restante."
@@ -395,8 +393,6 @@
    "outputs": [],
    "source": [
     "from matplotlib.pyplot import cm\n",
-    "from platiagro import save_figure\n",
-    "from platiagro import list_figures\n",
     "from sklearn.metrics import roc_curve, auc\n",
     "from sklearn import preprocessing\n",
     "import matplotlib.pyplot as plt\n",
@@ -424,7 +420,6 @@
     "        plt.ylabel('True Positive Rate')\n",
     "        plt.title('ROC Curve')\n",
     "        plt.legend(loc=\"lower right\")\n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "        \n",
     "    else:  \n",
@@ -456,7 +451,6 @@
     "            plt.title('ROC Curve One-vs-Rest')\n",
     "            plt.legend(loc=\"lower right\")\n",
     "        \n",
-    "        save_figure(figure=plt.gcf())\n",
     "        plt.show()\n",
     "\n",
     "plot_roc_curve(y_test,y_prob,labels)"
@@ -524,7 +518,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "1550eac4-931b-41f1-bf58-a958b2249620",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -540,9 +533,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "c0deb81a-540e-4d51-bf8f-c332f9b9fd73"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/svr/Deployment.ipynb
+++ b/samples/svr/Deployment.ipynb
@@ -203,7 +203,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "50ecf2eb-b805-4629-aea4-66053ed9ec8c",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -219,9 +219,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "104740b1-82c1-4321-9bd3-b2ef931f56f1"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/svr/Experiment.ipynb
+++ b/samples/svr/Experiment.ipynb
@@ -309,9 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Salva figuras\n",
-    "\n",
-    "Utiliza a função `save_figures` do [SDK da PlatIAgro](https://platiagro.github.io/sdk/) para salvar figuras do [matplotlib](https://matplotlib.org/3.2.1/gallery/index.html)."
+    "## Visualiza resultados"
    ]
   },
   {
@@ -320,7 +318,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from platiagro import save_figure\n",
     "from scipy.stats import gaussian_kde\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -402,9 +399,7 @@
     "annotate_plot(aux, 95, plt, y_lim, 1.2, abs_err)\n",
     "\n",
     "plt.grid(True)\n",
-    "plt.title(\"Error Distribution\")\n",
-    "\n",
-    "save_figure(figure=plt.gcf())"
+    "plt.title(\"Error Distribution\")"
    ]
   },
   {
@@ -459,7 +454,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "50ecf2eb-b805-4629-aea4-66053ed9ec8c",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -475,9 +469,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "104740b1-82c1-4321-9bd3-b2ef931f56f1"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/transformation-graph/Deployment.ipynb
+++ b/samples/transformation-graph/Deployment.ipynb
@@ -277,7 +277,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "71e1a12b-5305-4756-9b95-a25580f30d3e",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -293,10 +293,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "bd45f30b-2265-40d8-bd36-5440672f2e82"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/samples/transformation-graph/Experiment.ipynb
+++ b/samples/transformation-graph/Experiment.ipynb
@@ -177,7 +177,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "71e1a12b-5305-4756-9b95-a25580f30d3e",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -193,9 +192,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
-  },
-  "operator_id": "bd45f30b-2265-40d8-bd36-5440672f2e82"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/variance-threshold/Deployment.ipynb
+++ b/samples/variance-threshold/Deployment.ipynb
@@ -269,7 +269,7 @@
   }
  ],
  "metadata": {
-  "experiment_id": "bcf9dc81-6932-466c-95f3-588fc576f529",
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -285,9 +285,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  },
-  "operator_id": "b32c1336-a42d-4650-b31a-7afcc4729a86"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/samples/variance-threshold/Experiment.ipynb
+++ b/samples/variance-threshold/Experiment.ipynb
@@ -217,7 +217,6 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
-  "experiment_id": "bcf9dc81-6932-466c-95f3-588fc576f529",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -233,9 +232,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
-  },
-  "operator_id": "b32c1336-a42d-4650-b31a-7afcc4729a86"
+   "version": "3.7.8"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras = {
         "category-encoders==2.2.2",
         "auto-sklearn==0.7.0",
         "networkx==2.4",
-        "matplotlib===3.3.0"
+        "matplotlib==3.3.0"
     ]
 }
 


### PR DESCRIPTION
Calling save_figure is not necessary since pipelines now saves all
images in .ipynb outputs.