### PR TITLE
Allows nullable experiment_notebook

### DIFF
--- a/projects/jupyter.py
+++ b/projects/jupyter.py
@@ -106,6 +106,9 @@ def read_parameters(path):
     Returns:
         list: a list of parameters (name, default, type, label, description).
     """
+    if not path:
+        return []
+
     object_name = path[len(f"minio://{BUCKET_NAME}/"):]
     try:
         experiment_notebook = loads(get_object(object_name).decode("utf-8"))

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -331,6 +331,33 @@ class TestTasks(TestCase):
             self.assertDictEqual(expected, result)
             self.assertEqual(rv.status_code, 400)
 
+            # dataset task that has null notebooks
+            rv = c.post("/tasks", json={
+                "name": "fake dataset task",
+                "tags": ["DATASETS"],
+            })
+            result = rv.get_json()
+            expected = {
+                "name": "fake dataset task",
+                "description": None,
+                "tags": ["DATASETS"],
+                "isDefault": IS_DEFAULT,
+                "parameters": [],
+                "experimentNotebookPath": None,
+                "deploymentNotebookPath": None,
+                "image": 'platiagro/platiagro-notebook-image:0.1.0',
+            }
+            machine_generated = [
+                "uuid",
+                "createdAt",
+                "updatedAt",
+                "commands",
+            ]
+            for attr in machine_generated:
+                self.assertIn(attr, result)
+                del result[attr]
+            self.assertDictEqual(expected, result)
+
     def test_get_task(self):
         with app.test_client() as c:
             rv = c.get("/tasks/foo")


### PR DESCRIPTION
Improvement for tasks of tag 'DATASETS': they do not use Jupyter
Notebooks, so there is no need to create/upload .ipynb files for
them.