### PR TITLE
Adds default value='None' to Deployment.ipynb files

### DIFF
--- a/projects/config/Deployment.ipynb
+++ b/projects/config/Deployment.ipynb
@@ -34,7 +34,7 @@
     "    def __init__(self):\n",
     "        model = joblib.load(\"/tmp/data/model.joblib\")\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        # adicione seu código aqui...\n",
     "        return"
    ]

--- a/samples/automl-classifier/Deployment.ipynb
+++ b/samples/automl-classifier/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        column_names = np.concatenate((self.features_after_pipeline, self.new_columns))\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/automl-regressor/Deployment.ipynb
+++ b/samples/automl-regressor/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        )\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/feature-tools/Deployment.ipynb
+++ b/samples/feature-tools/Deployment.ipynb
@@ -124,7 +124,7 @@
     "    def class_names(self):\n",
     "        return self.features_names_training\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        data = pd.DataFrame(data=X, columns=self.features_names_training)\n",
     "\n",
     "        if feature_names:\n",

--- a/samples/filter-selection/Deployment.ipynb
+++ b/samples/filter-selection/Deployment.ipynb
@@ -45,7 +45,7 @@
     "    def class_names(self):\n",
     "        return self.features_filtered.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/grouping-categorical-features/Deployment.ipynb
+++ b/samples/grouping-categorical-features/Deployment.ipynb
@@ -74,7 +74,7 @@
     "    def class_names(self):\n",
     "        return self.features_after_pipeline.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "        X = pd.DataFrame(X, columns=feature_names)\n",
     "\n",

--- a/samples/imputer/Deployment.ipynb
+++ b/samples/imputer/Deployment.ipynb
@@ -47,7 +47,7 @@
     "    def class_names(self):\n",
     "        return self.features_after_pipeline.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/isolation-forest-clustering/Deployment.ipynb
+++ b/samples/isolation-forest-clustering/Deployment.ipynb
@@ -54,7 +54,7 @@
     "        column_names = np.concatenate((self.features_after_pipeline,self.new_columns))\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        # Coloca os dados em pandas.DataFrame para classificar\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "        \n",

--- a/samples/kmeans-clustering/Deployment.ipynb
+++ b/samples/kmeans-clustering/Deployment.ipynb
@@ -49,7 +49,7 @@
     "        column_names = np.concatenate((self.features_after_pipeline, self.new_columns))\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        # Coloca os dados em pandas.DataFrame para classificar\n",
     "        df = pd.DataFrame(X, columns=feature_names)\n",
     "\n",

--- a/samples/linear-regression/Deployment.ipynb
+++ b/samples/linear-regression/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        )\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/logistic-regression/Deployment.ipynb
+++ b/samples/logistic-regression/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        column_names = np.concatenate((self.features_after_pipeline, self.new_columns))\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/mlp-classifier/Deployment.ipynb
+++ b/samples/mlp-classifier/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        column_names = np.concatenate((self.features_after_pipeline, self.new_columns))\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/mlp-regressor/Deployment.ipynb
+++ b/samples/mlp-regressor/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        )\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/normalizer/Deployment.ipynb
+++ b/samples/normalizer/Deployment.ipynb
@@ -47,7 +47,7 @@
     "    def class_names(self):\n",
     "        return self.features_after_pipeline.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/pre-selection/Deployment.ipynb
+++ b/samples/pre-selection/Deployment.ipynb
@@ -65,7 +65,7 @@
     "    def class_names(self):\n",
     "        return self.features_after_pipeline.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "        if feature_names:\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/random-forest-classifier/Deployment.ipynb
+++ b/samples/random-forest-classifier/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        column_names = np.concatenate((self.features_after_pipeline, self.new_columns))\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/random-forest-regressor/Deployment.ipynb
+++ b/samples/random-forest-regressor/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        )\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/rfe-selector/Deployment.ipynb
+++ b/samples/rfe-selector/Deployment.ipynb
@@ -45,7 +45,7 @@
     "    def class_names(self):\n",
     "        return self.selected_features\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        return self.pipeline.transform(X)"
    ]
   },

--- a/samples/robust-scaler/Deployment.ipynb
+++ b/samples/robust-scaler/Deployment.ipynb
@@ -47,7 +47,7 @@
     "    def class_names(self):\n",
     "        return self.features_after_pipeline.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/simulated-annealing/Deployment.ipynb
+++ b/samples/simulated-annealing/Deployment.ipynb
@@ -124,7 +124,7 @@
     "    def class_names(self):\n",
     "        return self.features_names_training\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        data = pd.DataFrame(data=X, columns=self.features_names_training)\n",
     "\n",
     "        if feature_names:\n",

--- a/samples/svc/Deployment.ipynb
+++ b/samples/svc/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        column_names = np.concatenate((self.features_after_pipeline, self.new_columns))\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/svr/Deployment.ipynb
+++ b/samples/svr/Deployment.ipynb
@@ -52,7 +52,7 @@
     "        )\n",
     "        return column_names.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        if feature_names:\n",
     "            # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",

--- a/samples/transformation-graph/Deployment.ipynb
+++ b/samples/transformation-graph/Deployment.ipynb
@@ -124,7 +124,7 @@
     "    def class_names(self):\n",
     "        return self.features_names_training\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        data = pd.DataFrame(data=X, columns=self.features_names_training)\n",
     "\n",
     "        if feature_names:\n",

--- a/samples/variance-threshold/Deployment.ipynb
+++ b/samples/variance-threshold/Deployment.ipynb
@@ -47,7 +47,7 @@
     "    def class_names(self):\n",
     "        return self.features_after_pipeline.tolist()\n",
     "\n",
-    "    def predict(self, X, feature_names, meta):\n",
+    "    def predict(self, X, feature_names, meta=None):\n",
     "        # Antes de utilizar o conjunto de dados X no modelo, reordena suas features de acordo com a ordem utilizada no treinamento\n",
     "        if feature_names:\n",
     "            df = pd.DataFrame(X, columns=feature_names)\n",


### PR DESCRIPTION
When seldon receives a 'binData' or 'strData' it does not pass
'meta' to predict, causing deployments that used these notebooks
to crash.
By using a default value `meta=None` we avoid this bug.