### PR TITLE
Replaces relative imports by absolute imports

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -68,6 +68,8 @@ jobs:
           - async/await NÃO EXISTEM no Python3.6
           - Métodos que são chamados de outros arquivos `.py` **DEVEM TER Docstring**.
           - Usar Google Style Python Docstring: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
+          - Usar sempre import absoluto.
+            ex: from projects.database import Base (BOM), from .database import Base (RUIM)
     - name: Set output variables
       id: vars
       run: |

--- a/projects/api/compare_results.py
+++ b/projects/api/compare_results.py
@@ -3,9 +3,9 @@
 
 from flask import Blueprint, jsonify, request
 
-from ..controllers.compare_results import list_compare_results, create_compare_result, \
+from projects.controllers.compare_results import list_compare_results, create_compare_result, \
     update_compare_result, delete_compare_result
-from ..utils import to_snake_case
+from projects.utils import to_snake_case
 
 bp = Blueprint("compare_results", __name__)
 

--- a/projects/api/experiments.py
+++ b/projects/api/experiments.py
@@ -3,9 +3,9 @@
 
 from flask import Blueprint, jsonify, request
 
-from ..controllers.experiments import list_experiments, create_experiment, \
+from projects.controllers.experiments import list_experiments, create_experiment, \
     get_experiment, update_experiment, delete_experiment
-from ..utils import to_snake_case
+from projects.utils import to_snake_case
 
 bp = Blueprint("experiments", __name__)
 

--- a/projects/api/json_encoder.py
+++ b/projects/api/json_encoder.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from flask.json import JSONEncoder
 
-from ..database import Base
+from projects.database import Base
 
 
 class CustomJSONEncoder(JSONEncoder):

--- a/projects/api/main.py
+++ b/projects/api/main.py
@@ -8,16 +8,16 @@ from flask_cors import CORS
 from werkzeug.exceptions import BadRequest, NotFound, MethodNotAllowed, \
     Forbidden, InternalServerError
 
-from ..database import db_session, init_db
-from .compare_results import bp as compare_results_blueprint
-from .experiments import bp as experiments_blueprint
-from .json_encoder import CustomJSONEncoder
-from .operators import bp as operators_blueprint
-from .parameters import bp as parameters_blueprint
-from .projects import bp as projects_blueprint
-from .tasks import bp as tasks_blueprint
-from .templates import bp as templates_blueprint
-from ..samples import init_tasks
+from projects.api.compare_results import bp as compare_results_blueprint
+from projects.api.experiments import bp as experiments_blueprint
+from projects.api.json_encoder import CustomJSONEncoder
+from projects.api.operators import bp as operators_blueprint
+from projects.api.parameters import bp as parameters_blueprint
+from projects.api.projects import bp as projects_blueprint
+from projects.api.tasks import bp as tasks_blueprint
+from projects.api.templates import bp as templates_blueprint
+from projects.database import db_session, init_db
+from projects.samples import init_tasks
 
 app = Flask(__name__)
 app.json_encoder = CustomJSONEncoder

--- a/projects/api/operators.py
+++ b/projects/api/operators.py
@@ -3,9 +3,9 @@
 
 from flask import Blueprint, jsonify, request
 
-from ..controllers.operators import list_operators, create_operator, \
+from projects.controllers.operators import list_operators, create_operator, \
     update_operator, delete_operator
-from ..utils import to_snake_case
+from projects.utils import to_snake_case
 
 bp = Blueprint("operators", __name__)
 

--- a/projects/api/parameters.py
+++ b/projects/api/parameters.py
@@ -3,7 +3,7 @@
 
 from flask import Blueprint, jsonify
 
-from ..controllers.parameters import list_parameters
+from projects.controllers.parameters import list_parameters
 
 bp = Blueprint("parameters", __name__)
 

--- a/projects/api/projects.py
+++ b/projects/api/projects.py
@@ -3,10 +3,10 @@
 
 from flask import jsonify, request
 from flask_smorest import Blueprint
-from ..controllers.projects import create_project, \
+from projects.controllers.projects import create_project, \
     get_project, update_project, delete_project, pagination_projects, \
     delete_multiple_projects
-from ..utils import to_snake_case
+from projects.utils import to_snake_case
 
 bp = Blueprint("projects", __name__)
 

--- a/projects/api/tasks.py
+++ b/projects/api/tasks.py
@@ -4,9 +4,9 @@
 from flask import jsonify, request
 from flask_smorest import Blueprint
 
-from ..controllers.tasks import create_task, get_task, update_task, \
+from projects.controllers.tasks import create_task, get_task, update_task, \
      delete_task, pagination_tasks
-from ..utils import to_snake_case
+from projects.utils import to_snake_case
 
 bp = Blueprint("tasks", __name__)
 

--- a/projects/api/templates.py
+++ b/projects/api/templates.py
@@ -3,9 +3,9 @@
 
 from flask import Blueprint, jsonify, request
 
-from ..controllers.templates import list_templates, create_template, \
+from projects.controllers.templates import list_templates, create_template, \
     get_template, update_template, delete_template
-from ..utils import to_snake_case
+from projects.utils import to_snake_case
 
 bp = Blueprint("templates", __name__)
 

--- a/projects/controllers/compare_results.py
+++ b/projects/controllers/compare_results.py
@@ -6,10 +6,10 @@ from datetime import datetime
 from sqlalchemy.exc import InvalidRequestError, ProgrammingError
 from werkzeug.exceptions import BadRequest, NotFound
 
-from ..database import db_session
-from ..models import CompareResult
-from .utils import raise_if_project_does_not_exist, raise_if_experiment_does_not_exist, \
-    uuid_alpha
+from projects.controllers.utils import raise_if_project_does_not_exist, \
+    raise_if_experiment_does_not_exist, uuid_alpha
+from projects.database import db_session
+from projects.models import CompareResult
 
 
 NOT_FOUND = NotFound("The specified compare result does not exist")

--- a/projects/controllers/dependencies.py
+++ b/projects/controllers/dependencies.py
@@ -2,9 +2,10 @@
 """Dependency controller."""
 from werkzeug.exceptions import NotFound
 
-from ..database import db_session
-from ..models import Dependency
-from .utils import raise_if_operator_does_not_exist, uuid_alpha
+from projects.controllers.utils import raise_if_operator_does_not_exist, \
+    uuid_alpha
+from projects.database import db_session
+from projects.models import Dependency
 
 
 def list_dependencies(operator_id):

--- a/projects/controllers/experiments.py
+++ b/projects/controllers/experiments.py
@@ -7,12 +7,12 @@ from os.path import join
 from sqlalchemy.exc import InvalidRequestError, ProgrammingError
 from werkzeug.exceptions import BadRequest, NotFound
 
-from ..database import db_session
-from ..models import CompareResult, Dependency, Experiment, Operator, Template
-from ..object_storage import remove_objects
-from .dependencies import create_dependency
-from .operators import create_operator, update_operator
-from .utils import raise_if_project_does_not_exist, uuid_alpha
+from projects.controllers.dependencies import create_dependency
+from projects.controllers.operators import create_operator, update_operator
+from projects.controllers.utils import raise_if_project_does_not_exist, uuid_alpha
+from projects.database import db_session
+from projects.models import CompareResult, Dependency, Experiment, Operator, Template
+from projects.object_storage import remove_objects
 
 
 NOTFOUND = NotFound("The specified experiment does not exist")

--- a/projects/controllers/operators.py
+++ b/projects/controllers/operators.py
@@ -5,14 +5,14 @@ from datetime import datetime
 from sqlalchemy.exc import InvalidRequestError, ProgrammingError
 from werkzeug.exceptions import BadRequest, NotFound
 
-from ..database import db_session
-from ..models import Operator, Task
-from .parameters import list_parameters
-from .dependencies import list_dependencies, list_next_operators, \
+from projects.controllers.dependencies import list_dependencies, list_next_operators, \
     create_dependency, delete_dependency
-from .utils import raise_if_task_does_not_exist, \
+from projects.controllers.parameters import list_parameters
+from projects.controllers.utils import raise_if_task_does_not_exist, \
     raise_if_project_does_not_exist, raise_if_experiment_does_not_exist, \
     raise_if_operator_does_not_exist, uuid_alpha
+from projects.database import db_session
+from projects.models import Operator, Task
 
 
 PARAMETERS_EXCEPTION_MSG = "The specified parameters are not valid"

--- a/projects/controllers/parameters.py
+++ b/projects/controllers/parameters.py
@@ -3,8 +3,8 @@
 
 from werkzeug.exceptions import NotFound
 
-from ..models import Task
-from ..jupyter import read_parameters
+from projects.jupyter import read_parameters
+from projects.models import Task
 
 
 def list_parameters(task_id, is_checked=False):

--- a/projects/controllers/projects.py
+++ b/projects/controllers/projects.py
@@ -9,11 +9,11 @@ from sqlalchemy import asc, desc, text
 from sqlalchemy.exc import InvalidRequestError, ProgrammingError, OperationalError, InternalError
 from werkzeug.exceptions import BadRequest, NotFound, InternalServerError
 
-from .experiments import create_experiment
-from ..database import db_session
-from ..models import Dependency, Experiment, Operator, Project
-from ..object_storage import remove_objects
-from .utils import uuid_alpha, list_objects, objects_uuid, text_to_list
+from projects.controllers.experiments import create_experiment
+from projects.controllers.utils import uuid_alpha, list_objects, objects_uuid, text_to_list
+from projects.database import db_session
+from projects.models import Dependency, Experiment, Operator, Project
+from projects.object_storage import remove_objects
 
 
 NOT_FOUND = NotFound('The specified project does not exist')

--- a/projects/controllers/tasks.py
+++ b/projects/controllers/tasks.py
@@ -13,13 +13,13 @@ from sqlalchemy.exc import InvalidRequestError, IntegrityError, ProgrammingError
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound, InternalServerError
 
 
-from ..database import db_session
-from ..jupyter import create_new_file, list_files, delete_file, update_folder_name
-from ..models import Task
-from ..models.task import DEFAULT_COMMANDS, DEFAULT_ARGUMENTS
-from ..object_storage import BUCKET_NAME, get_object, put_object, \
+from projects.controllers.utils import uuid_alpha, text_to_list
+from projects.database import db_session
+from projects.jupyter import create_new_file, list_files, delete_file, update_folder_name
+from projects.models import Task
+from projects.models.task import DEFAULT_COMMANDS, DEFAULT_ARGUMENTS
+from projects.object_storage import BUCKET_NAME, get_object, put_object, \
     list_objects, remove_object
-from .utils import uuid_alpha, text_to_list
 
 PREFIX = "tasks"
 VALID_TAGS = ["DATASETS", "DEFAULT", "DESCRIPTIVE_STATISTICS", "FEATURE_ENGINEERING", "PREDICTOR"]
@@ -475,5 +475,5 @@ def uninformed_page(query, order):
         query = query.order_by(asc(text(f'{order[0]}')))
     elif 'desc' == order[1].lower():
         query = query.order_by(desc(text(f'{order[0]}')))
-    
+
     return query

--- a/projects/controllers/templates.py
+++ b/projects/controllers/templates.py
@@ -6,9 +6,9 @@ from datetime import datetime
 from sqlalchemy.exc import InvalidRequestError, ProgrammingError
 from werkzeug.exceptions import BadRequest, NotFound
 
-from ..database import db_session
-from ..models import Template, Operator
-from .utils import raise_if_experiment_does_not_exist, uuid_alpha
+from projects.controllers.utils import raise_if_experiment_does_not_exist, uuid_alpha
+from projects.database import db_session
+from projects.models import Template, Operator
 
 
 def list_templates():

--- a/projects/controllers/utils.py
+++ b/projects/controllers/utils.py
@@ -6,8 +6,8 @@ import re
 
 from werkzeug.exceptions import NotFound
 
-from ..database import db_session
-from ..models import Experiment, Operator, Project, Task
+from projects.database import db_session
+from projects.models import Experiment, Operator, Project, Task
 
 
 def raise_if_task_does_not_exist(task_id):

--- a/projects/jupyter.py
+++ b/projects/jupyter.py
@@ -10,7 +10,7 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
 from requests.packages.urllib3.util.retry import Retry
 
-from .object_storage import BUCKET_NAME, get_object
+from projects.object_storage import BUCKET_NAME, get_object
 
 JUPYTER_ENDPOINT = getenv("JUPYTER_ENDPOINT", "http://server.anonymous:80/notebook/anonymous/server")
 URL_CONTENTS = f"{JUPYTER_ENDPOINT}/api/contents"

--- a/projects/models/__init__.py
+++ b/projects/models/__init__.py
@@ -1,9 +1,9 @@
-from .compare_result import CompareResult
-from .dependencies import Dependency
-from .experiment import Experiment
-from .operators import Operator
-from .project import Project
-from .task import Task
-from .template import Template
+from projects.models.compare_result import CompareResult
+from projects.models.dependency import Dependency
+from projects.models.experiment import Experiment
+from projects.models.operator import Operator
+from projects.models.project import Project
+from projects.models.task import Task
+from projects.models.template import Template
 
 __all__ = ['CompareResult', 'Dependency', 'Experiment', 'Operator', 'Project', 'Task', 'Template']

--- a/projects/models/compare_result.py
+++ b/projects/models/compare_result.py
@@ -4,8 +4,8 @@ from datetime import datetime
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 
-from ..database import Base
-from ..utils import to_camel_case
+from projects.database import Base
+from projects.utils import to_camel_case
 
 
 class CompareResult(Base):

--- a/projects/models/dependency.py
+++ b/projects/models/dependency.py
@@ -2,8 +2,8 @@
 """Dependency model."""
 from sqlalchemy import Column, String, ForeignKey
 
-from ..database import Base
-from ..utils import to_camel_case
+from projects.database import Base
+from projects.utils import to_camel_case
 
 
 class Dependency(Base):

--- a/projects/models/experiment.py
+++ b/projects/models/experiment.py
@@ -6,9 +6,9 @@ from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, Foreign
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
-from .operators import Operator
-from ..database import Base
-from ..utils import to_camel_case
+from projects.models.operator import Operator
+from projects.database import Base
+from projects.utils import to_camel_case
 
 
 class Experiment(Base):

--- a/projects/models/operator.py
+++ b/projects/models/operator.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from sqlalchemy import Column, DateTime, JSON, String, ForeignKey, Float
 from sqlalchemy.orm import relationship
 
-from .dependencies import Dependency
-from ..database import Base
-from ..utils import to_camel_case
+from projects.models.dependency import Dependency
+from projects.database import Base
+from projects.utils import to_camel_case
 
 
 class Operator(Base):

--- a/projects/models/project.py
+++ b/projects/models/project.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from sqlalchemy import Column, DateTime, String, Text
 from sqlalchemy.orm import relationship
 
-from ..database import Base
-from ..utils import to_camel_case
+from projects.database import Base
+from projects.utils import to_camel_case
 
 
 class Project(Base):

--- a/projects/models/task.py
+++ b/projects/models/task.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from sqlalchemy import Boolean, Column, DateTime, JSON, String, Text
 from sqlalchemy.sql import expression
 
-from ..database import Base
-from ..jupyter import read_parameters
-from ..utils import to_camel_case
+from projects.database import Base
+from projects.jupyter import read_parameters
+from projects.utils import to_camel_case
 
 DEFAULT_IMAGE = 'platiagro/platiagro-notebook-image:0.1.0'
 DEFAULT_COMMANDS = ['sh', '-c']

--- a/projects/models/template.py
+++ b/projects/models/template.py
@@ -4,8 +4,8 @@ from datetime import datetime
 
 from sqlalchemy import Column, DateTime, JSON, String, Text
 
-from ..database import Base
-from ..utils import to_camel_case
+from projects.database import Base
+from projects.utils import to_camel_case
 
 
 class Template(Base):

--- a/projects/samples.py
+++ b/projects/samples.py
@@ -3,7 +3,7 @@ from json import load
 
 from werkzeug.exceptions import BadRequest
 
-from .controllers.tasks import create_task
+from projects.controllers.tasks import create_task
 
 
 def init_tasks(config_path):


### PR DESCRIPTION
This was changed because PEP 8 encourages absolute imports:
See https://www.python.org/dev/peps/pep-0008/ for further details.

Also added a instruction to use absolute imports in code-review tips.