### PR TITLE
Add Tasks in the metadata.annotations of the Pod Object

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1019,7 +1019,7 @@ paths:
         $ref: "#/components/requestBodies/DeploymentPost"
       responses:
         "200":
-          $ref: "#/components/responses/Deployment"
+          $ref: "#/components/responses/Deployments"
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":
@@ -1557,7 +1557,7 @@ components:
         operators:
           type: array
           items:
-            oneOf:
+            allOf:
               - $ref: "#/components/schemas/Operator"
               - type: object
                 properties:
@@ -1662,7 +1662,7 @@ components:
             properties:
               status:
                 type: string
-                enum: [Unset, Setted up]
+                enum: [Unset, Setted up, Pending, Running, Failed, Successful]
                 example: Setted up
     ExperimentLog:
       type: object
@@ -2090,16 +2090,21 @@ components:
                 type: string
                 format: uuid
     DeploymentPost:
-      description: Necessary body if experimentDeploy equals true
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              name:
-                type: string
-              copyFrom:
-                type: string
+            oneOf:
+              - $ref: "#/components/schemas/DeploymentExperiments"
+              - $ref: "#/components/schemas/DeploymentTemplate"
+          examples:
+            experiments:
+              summary: From a list of experiments
+              value:
+                experiments: ["3fa85f64-5717-4562-b3fc-2c963f66afa6"]
+            template:
+              summary: From a template
+              value:
+                templateId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
     DeploymentPatch:
       content:
         application/json:
@@ -2163,15 +2168,7 @@ components:
         application/json:
           schema:
             type: object
-            properties:
-              experimentId:
-                type: string
-                format: uuid
-              operators:
-                type: array
-                items:
-                  oneOf:
-                    - $ref: "#/components/schemas/Operator"
+            properties: {}
     TemplatePost:
       content:
         application/json:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1019,7 +1019,7 @@ paths:
         $ref: "#/components/requestBodies/DeploymentPost"
       responses:
         "200":
-          $ref: "#/components/responses/Deployments"
+          $ref: "#/components/responses/Deployment"
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":
@@ -1223,14 +1223,14 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectsId}/deployments/{deploymentId}/runs/{runId}/logs:
+  /projects/{projectId}/deployments/{deploymentId}/runs/{runId}/logs:
     get:
-      summary: "Get logs from a deployment run."
+      summary: "Get logs from a deployment run"
       tags:
         - "Results"
       parameters:
         - in: path
-          name: projectsId
+          name: projectId
           required: true
           schema:
             type: string
@@ -1530,10 +1530,15 @@ components:
         hasPreDeployment:
           type: string
     Projects:
-      type: array
-      items:
-        oneOf:
-          - $ref: "#/components/schemas/Project"
+      type: object
+      properties:
+        projects:
+          type: array
+          items:
+            oneOf:
+              - $ref: "#/components/schemas/Project"
+        total:
+          type: integer
     Experiment:
       type: object
       properties:
@@ -1552,7 +1557,7 @@ components:
         operators:
           type: array
           items:
-            allOf:
+            oneOf:
               - $ref: "#/components/schemas/Operator"
               - type: object
                 properties:
@@ -1615,18 +1620,6 @@ components:
         templateId:
           type: string
           format: uuid
-    DeploymentLog:
-      type: array
-      items:
-        type: object
-        properties:
-          containerName:
-            type: string
-          logs:
-            type: array
-            items:
-              oneOf:
-                - $ref: "#/components/schemas/Log"
     Operator:
       type: object
       properties:
@@ -1669,7 +1662,7 @@ components:
             properties:
               status:
                 type: string
-                enum: [Unset, Setted up, Pending, Running, Failed, Successful]
+                enum: [Unset, Setted up]
                 example: Setted up
     ExperimentLog:
       type: object
@@ -1696,15 +1689,35 @@ components:
               - "   4861 "
               - ""
               - "KeyError: ['species']"
-    Log:
-      type: object
-      properties:
-        level:
-          type: string
-        message:
-          type: string
-        timestamp:
-          type: string
+    DeploymentLog:
+      type: array
+      items:
+        oneOf:
+        - type: object
+          properties:
+            containerName:
+              type: string
+              example: Regressor Random Forest
+            logs:
+              type: array
+              items:
+                allOf:
+                - type: object
+                  properties:
+                    level:
+                      type: string
+                      enum: [DEBUG, INFO, WARNING, ERROR]
+                      example: INFO
+                    message:
+                      type: string
+                      example: seldon_core.microservice:load_annotations:114 Found annotation deployment_version
+                    timestamp:
+                      type: string
+                      format: date-time
+            status:
+              type: string
+              enum: [Creating, Completed]
+              example: Completed
     Datasets:
       type: array
       items:
@@ -2077,21 +2090,16 @@ components:
                 type: string
                 format: uuid
     DeploymentPost:
+      description: Necessary body if experimentDeploy equals true
       content:
         application/json:
           schema:
-            oneOf:
-              - $ref: "#/components/schemas/DeploymentExperiments"
-              - $ref: "#/components/schemas/DeploymentTemplate"
-          examples:
-            experiments:
-              summary: From a list of experiments
-              value:
-                experiments: ["3fa85f64-5717-4562-b3fc-2c963f66afa6"]
-            template:
-              summary: From a template
-              value:
-                templateId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+            type: object
+            properties:
+              name:
+                type: string
+              copyFrom:
+                type: string
     DeploymentPatch:
       content:
         application/json:
@@ -2155,7 +2163,15 @@ components:
         application/json:
           schema:
             type: object
-            properties: {}
+            properties:
+              experimentId:
+                type: string
+                format: uuid
+              operators:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/Operator"
     TemplatePost:
       content:
         application/json:

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -62,11 +62,11 @@ def list_logs(project_id, deployment_id, run_id):
                 tasks = pod.metadata.annotations.get("tasks")
                 tasks = literal_eval(tasks)
 
-                operatorInfo = {}
-                operatorInfo['containerName'] = tasks[container.name]
-                operatorInfo['logs'] = log_parser(pod_log)
-                operatorInfo.update({'status': 'Completed'})
-                response.append(operatorInfo)
+                operator_info = {}
+                operator_info['containerName'] = tasks[container.name]
+                operator_info['logs'] = log_parser(pod_log)
+                operator_info.update({'status': 'Completed'})
+                response.append(operator_info)
 
     return response
 

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Deployments Logs controller."""
 import re
+
+from ast import literal_eval
 from io import StringIO
 
 from projects.controllers.utils import raise_if_project_does_not_exist, \
@@ -40,10 +42,11 @@ def list_logs(project_id, deployment_id, run_id):
     raise_if_deployment_does_not_exist(deployment_id)
 
     deployment_pods = list_deployment_pods(deployment_id)
-    log = {'status': 'Starting'}
+    response = []
+    status = {'status': 'Starting'}
 
     if not deployment_pods:
-        log.update({'status': 'Creating'})
+        return status
 
     for pod in deployment_pods:
         for container in pod.spec.containers:
@@ -51,14 +54,21 @@ def list_logs(project_id, deployment_id, run_id):
                 pod_log = get_pod_log(pod, container)
 
                 if not pod_log:
-                    log.update({'status': 'Creating'})
-                    return log
+                    status.update({'status': 'Creating'})
+                    return status
 
-                log['containerName'] = get_operator_name(container.name)
-                log['logs'] = log_parser(pod_log)
-                log['status'] = 'Completed'
-                log = [log]
-    return log
+                # retrieves the name of the task linked to the operator 
+                # in the pod "metadata.annotations.tasks"
+                tasks = pod.metadata.annotations.get("tasks")
+                tasks = literal_eval(tasks)
+
+                operatorInfo = {}
+                operatorInfo['containerName'] = tasks[container.name]
+                operatorInfo['logs'] = log_parser(pod_log)
+                operatorInfo.update({'status': 'Completed'})
+                response.append(operatorInfo)
+
+    return response
 
 
 def log_parser(raw_log):
@@ -102,32 +112,3 @@ def log_parser(raw_log):
         line = buf.readline()
 
     return logs
-
-
-def get_operator_name(container_name):
-    """
-    Get task name from a container.
-
-    Parameters
-    ----------
-    container_name : str
-
-    Returns
-    -------
-    str
-        The task name.
-
-    Notes
-    -----
-    If the container is not linked to any operator, it returns the name of the container.
-    """
-    # get task name
-    # TODO: deixar o nome da task visivel no arquivo yaml deste container
-    operator = Operator.query.get(container_name)
-
-    if operator:
-        task = Task.query.get(operator.task_id)
-        if task:
-            return task.name
-
-    return container_name

--- a/projects/kfp/pipeline.py
+++ b/projects/kfp/pipeline.py
@@ -215,7 +215,10 @@ def create_resource_op(operators, project_id, experiment_id, deployment_id, depl
     kfp.dsl.ResourceOp
     """
     component_specs = []
+    tasks = {}
+
     for operator in operators:
+        tasks.update({operator.uuid: operator.task.name})
         component_specs.append(
             COMPONENT_SPEC.substitute({
                 "operatorId": operator.uuid,
@@ -258,6 +261,7 @@ def create_resource_op(operators, project_id, experiment_id, deployment_id, depl
         "componentSpecs": ",".join(component_specs),
         "graph": graph,
         "projectId": project_id,
+        "tasks": tasks,
     })
 
     sdep_resource = loads(seldon_deployment)

--- a/projects/kfp/templates.py
+++ b/projects/kfp/templates.py
@@ -31,6 +31,9 @@ SELDON_DEPLOYMENT = Template("""{
             {
                 "componentSpecs": [$componentSpecs
                 ],
+                "annotations": {
+                    "tasks": "$tasks"
+                },
                 "graph": $graph,
                 "labels": {
                     "version": "v1"


### PR DESCRIPTION
- retrives operator task name from `metadata.annotations.tasks`
- update swagger: add status to the Deployment log section