### PR TITLE
Sets seldon deployment image using env variable

### DIFF
--- a/projects/api/projects.py
+++ b/projects/api/projects.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Projects API Router."""
-import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, Request

--- a/projects/kfp/templates.py
+++ b/projects/kfp/templates.py
@@ -60,7 +60,7 @@ COMPONENT_SPEC = Template("""
     "spec": {
         "containers": [
             {
-                "image": "platiagro/platiagro-deployment-image:0.2.0",
+                "image": "$image",
                 "name": "$operatorId",
                 "securityContext": {
                     "allowPrivilegeEscalation": false,

--- a/projects/models/task.py
+++ b/projects/models/task.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql import expression
 from projects import __version__
 from projects.database import Base
 
-DEFAULT_IMAGE = os.getenv("DEFAULT_IMAGE", f'platiagro/platiagro-experiment-image:{__version__}')
+DEFAULT_IMAGE = os.getenv("TASK_DEFAULT_EXPERIMENT_IMAGE", f'platiagro/platiagro-experiment-image:{__version__}')
 
 
 class Task(Base):


### PR DESCRIPTION
Uses the new env variable defined in manifests:
TASK_DEFAULT_DEPLOYMENT_IMAGE

Also renames the image for experiments to
TASK_DEFAULT_EXPERIMENT_IMAGE

Usa os nomes definidos no repo manifests:
https://github.com/platiagro/manifests/blob/2cbcb9058968966bda5ef01a1804ff32e26219d5/platiagro/projects/base/deployment.yaml#L41