### PR TITLE
Set status=Pending in operators when a run starts

### DIFF
--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -91,6 +91,12 @@ class RunController:
         except ValueError as e:
             raise BadRequest(str(e))
 
+        update_data = {"status": "Pending"}
+        self.session.query(models.Operator) \
+            .filter_by(deployment_id=deployment_id) \
+            .update(update_data)
+        self.session.commit()
+
         run["deploymentId"] = deployment_id
         return run
 

--- a/projects/controllers/experiments/runs/runs.py
+++ b/projects/controllers/experiments/runs/runs.py
@@ -83,6 +83,12 @@ class RunController:
                                  operators=experiment.operators)
         run["experimentId"] = experiment_id
 
+        update_data = {"status": "Pending"}
+        self.session.query(models.Operator) \
+            .filter_by(experiment_id=experiment_id) \
+            .update(update_data)
+        self.session.commit()
+
         return schemas.Run.from_model(run)
 
     def get_run(self, project_id: str, experiment_id: str, run_id: str):


### PR DESCRIPTION
Necesssary since persistence-agent has a delay to update the status,
and a bad feedback was provided in web-ui (it seemed nothing changed
in operator' status.