### PR TITLE
Fix logs list when seldon deployment fails

### DIFF
--- a/projects/api/deployments/runs/logs.py
+++ b/projects/api/deployments/runs/logs.py
@@ -36,11 +36,10 @@ async def handle_list_logs(project_id: str,
     project_controller.raise_if_project_does_not_exist(project_id)
 
     deployment_controller = DeploymentController(session)
-    deployment_controller.raise_if_deployment_does_not_exist(deployment_id=deployment_id)
+    deployment_controller.raise_if_deployment_does_not_exist(deployment_id)
 
     run_controller = RunController(session)
-    run_controller.raise_if_run_does_not_exist(run_id=run_id,
-                                               deployment_id=deployment_id)
+    run_controller.raise_if_run_does_not_exist(run_id, deployment_id)
 
     log_controller = LogController(session)
     logs = log_controller.list_logs(project_id=project_id,

--- a/projects/api/deployments/runs/logs.py
+++ b/projects/api/deployments/runs/logs.py
@@ -36,12 +36,11 @@ async def handle_list_logs(project_id: str,
     project_controller.raise_if_project_does_not_exist(project_id)
 
     deployment_controller = DeploymentController(session)
-    deployment = deployment_controller.get_deployment(project_id=project_id,
-                                                      deployment_id=deployment_id)
+    deployment_controller.raise_if_deployment_does_not_exist(deployment_id=deployment_id)
 
     run_controller = RunController(session)
     run_controller.raise_if_run_does_not_exist(run_id=run_id,
-                                               experiment_id=deployment.experiment_id)
+                                               deployment_id=deployment_id)
 
     log_controller = LogController(session)
     logs = log_controller.list_logs(project_id=project_id,

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -7,7 +7,7 @@ from io import StringIO
 from projects.kubernetes.seldon import list_deployment_pods
 from projects.kubernetes.utils import get_container_logs
 
-EXCLUDE_CONTAINERS = ['istio-proxy']
+EXCLUDE_CONTAINERS = ["istio-proxy", "seldon-container-engine"]
 TIME_STAMP_PATTERN = r'\d{4}-\d{2}-\d{2}(:?\s|T)\d{2}:\d{2}:\d{2}(:?.|,)\d+Z?\s?'
 LOG_MESSAGE_PATTERN = r'[a-zA-Z0-9\u00C0-\u00D6\u00D8-\u00f6\u00f8-\u00ff\"\'.\-@_,!#$%^&*()\[\]<>?\/|}{~:]{1,}'
 LOG_LEVEL_PATTERN = r'(?<![\\w\\d])INFO(?![\\w\\d])|(?<![\\w\\d])WARNING(?![\\w\\d])|(?<![\\w\\d])WARN(?![\\w\\d])|(?<![\\w\\d])ERROR(?![\\w\\d])'
@@ -39,8 +39,8 @@ class LogController:
             for container in pod.spec.containers:
                 if container.name not in EXCLUDE_CONTAINERS:
                     logs = get_container_logs(pod, container)
-
                     status = "Completed" if logs is not None else "Creating"
+
                     task_name = next((e.value for e in container.env if e.name == "TASK_NAME"), pod.metadata.name)
 
                     operator_info = {

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -46,13 +46,13 @@ class LogController:
                     operator_info = {
                         "status": status,
                         "containerName": task_name,
-                        "logs": logs,
+                        "logs": self.parse_logs(logs),
                     }
                     response.append(operator_info)
 
         return response
 
-    def log_parser(self, raw_log):
+    def parse_logs(self, raw_log):
         """
         Transform raw log text into human-readable logs.
 

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -4,7 +4,6 @@ import re
 
 from io import StringIO
 
-from projects import models
 from projects.kubernetes.seldon import list_deployment_pods
 from projects.kubernetes.utils import get_container_logs
 

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -19,21 +19,21 @@ class RunController:
     def __init__(self, session):
         self.session = session
 
-    def raise_if_run_does_not_exist(self, run_id: str, experiment_id: str):
+    def raise_if_run_does_not_exist(self, run_id: str, deployment_id: str):
         """
         Raises an exception if the specified run does not exist.
 
         Parameters
         ----------
         run_id : str
-        experiment_id : str
+        deployment_id : str
 
         Raises
         ------
         NotFound
         """
         try:
-            kfp_runs.get_run(experiment_id=experiment_id,
+            kfp_runs.get_run(experiment_id=deployment_id,
                              run_id=run_id)
         except (ApiException, ValueError):
             raise NOT_FOUND

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -51,8 +51,7 @@ class RunController:
         -------
         projects.schemas.run.RunList
         """
-        runs = get_deployment_runs(deployment_id)
-
+        runs = kfp_runs.list_runs(experiment_id=deployment_id)
         return schemas.RunList.from_model(runs, len(runs))
 
     def create_run(self, project_id: str, deployment_id: str):

--- a/projects/kfp/pipeline.py
+++ b/projects/kfp/pipeline.py
@@ -243,10 +243,8 @@ def create_resource_op(operators, project_id, experiment_id, deployment_id, depl
     kfp.dsl.ResourceOp
     """
     component_specs = []
-    tasks = {"sidecar.istio.io/inject": "false"}
 
     for operator in operators:
-        tasks.update({operator.uuid: operator.task_id})
         component_specs.append(
             COMPONENT_SPEC.substitute({
                 "image": TASK_DEFAULT_DEPLOYMENT_IMAGE,
@@ -256,6 +254,7 @@ def create_resource_op(operators, project_id, experiment_id, deployment_id, depl
                 "taskId": operator.task.uuid,
                 "memoryRequest": MEMORY_REQUEST,
                 "memoryLimit": MEMORY_LIMIT,
+                "taskName": operator.task.name,
             })
         )
 
@@ -298,7 +297,6 @@ def create_resource_op(operators, project_id, experiment_id, deployment_id, depl
         "componentSpecs": ",".join(component_specs),
         "graph": dumps(graph),
         "projectId": project_id,
-        "tasks": dumps(tasks),
         "restTimeout": SELDON_REST_TIMEOUT,
     })
 

--- a/projects/kfp/runs.py
+++ b/projects/kfp/runs.py
@@ -34,20 +34,17 @@ def list_runs(experiment_id):
 
     # Now, lists runs
     kfp_runs = kfp_client().list_runs(
-        page_size="100",
+        page_size="10",
         sort_by="created_at desc",
         experiment_id=kfp_experiment.id,
     )
 
     runs = []
     for kfp_run in kfp_runs.runs:
-        workflow_manifest = json.loads(kfp_run.pipeline_spec.workflow_manifest)
-        if workflow_manifest["metadata"]["generateName"] == f"experiment-{experiment_id}-":
-            run_id = kfp_run.id
-            run = get_run(experiment_id=experiment_id,
-                          run_id=run_id)
-
-            runs.append(run)
+        run_id = kfp_run.id
+        run = get_run(experiment_id=experiment_id,
+                      run_id=run_id)
+        runs.append(run)
 
     return runs
 
@@ -183,7 +180,7 @@ def get_latest_run_id(experiment_id):
 
     # lists runs for trainings and deployments of an experiment
     kfp_runs = kfp_client().list_runs(
-        page_size="100",
+        page_size="1",
         sort_by="created_at desc",
         experiment_id=kfp_experiment.id,
     )
@@ -191,10 +188,8 @@ def get_latest_run_id(experiment_id):
     # find the latest training run
     latest_run_id = None
     for kfp_run in kfp_runs.runs:
-        workflow_manifest = json.loads(kfp_run.pipeline_spec.workflow_manifest)
-        if workflow_manifest["metadata"]["generateName"] == f"experiment-{experiment_id}-":
-            latest_run_id = kfp_run.id
-            break
+        latest_run_id = kfp_run.id
+        break
 
     return latest_run_id
 

--- a/projects/kfp/runs.py
+++ b/projects/kfp/runs.py
@@ -84,7 +84,11 @@ def start_run(operators, project_id, experiment_id, deployment_id=None, deployme
                      deployment_id=deployment_id,
                      deployment_name=deployment_name)
 
-    kfp_experiment = kfp_client().create_experiment(name=experiment_id)
+    if deployment_id is not None:
+        kfp_experiment = kfp_client().create_experiment(name=deployment_id)
+    else:
+        kfp_experiment = kfp_client().create_experiment(name=experiment_id)
+
     tag = datetime.utcnow().strftime("%Y-%m-%d %H-%M-%S")
 
     job_name = f"{name}-{tag}"

--- a/projects/kfp/templates.py
+++ b/projects/kfp/templates.py
@@ -25,7 +25,9 @@ SELDON_DEPLOYMENT = Template("""{
             {
                 "componentSpecs": [$componentSpecs
                 ],
-                "annotations": $tasks,
+                "annotations": {
+                    "sidecar.istio.io/inject": "false"
+                },
                 "graph": $graph,
                 "labels": {
                     "version": "v1"
@@ -65,6 +67,10 @@ COMPONENT_SPEC = Template("""
                     {
                         "name": "OPERATOR_ID",
                         "value": "$operatorId"
+                    },
+                    {
+                        "name": "TASK_NAME",
+                        "value": "$taskName"
                     }
                 ],
                 "volumeMounts": [

--- a/projects/kubernetes/utils.py
+++ b/projects/kubernetes/utils.py
@@ -37,14 +37,14 @@ def search_for_pod_info(details, operator_id):
     return info
 
 
-def get_pod_log(pod, container):
+def get_container_logs(pod, container):
     """
-    Read log of the specified Pod.
+    Returns latest logs of the specified container.
 
     Parameters
     ----------
-    pod : kubernetes.client.models.v1_pod.V1Pod
-    container : kubernetes.client.models.v1_container.V1Container
+    pod : str
+    container : str
 
     Returns
     -------
@@ -60,22 +60,22 @@ def get_pod_log(pod, container):
     core_api = client.CoreV1Api()
 
     try:
-        pod_log = core_api.read_namespaced_pod_log(
-                        name=pod.metadata.name,
-                        namespace=KF_PIPELINES_NAMESPACE,
-                        container=container.name,
-                        pretty='true',
-                        tail_lines=512,
-                        timestamps=True
-                    )
+        logs = core_api.read_namespaced_pod_log(
+            name=pod.metadata.name,
+            namespace=KF_PIPELINES_NAMESPACE,
+            container=container.name,
+            pretty="true",
+            tail_lines=512,
+            timestamps=True,
+        )
 
-        return pod_log
+        return logs
     except ApiException as e:
         body = literal_eval(e.body)
-        message = body['message']
+        message = body["message"]
 
-        if 'ContainerCreating' in message:
-            return []
+        if "ContainerCreating" in message:
+            return None
         raise InternalServerError(f"Error while trying to retrive container's log: {message}")
 
 


### PR DESCRIPTION
Fix logs list when seldon deployment fails

Fix get_latest_run_id …
Don't check workflow manifest name == 'experiment-...', it's
unnecessary and caused get_latest_run_id to fail for deployments.

Uses deployment_id as kfp.experiment name …
Allows to retrieve deployment runs easier that before (when
we had to use deployment.experiment_id).

Calls parse_logs to return structured logs
 
Hides seldon-container-engine from deployment logs