### PR TITLE
Returns workflow logs when seldondeployments don't exist

### DIFF
--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -72,8 +72,8 @@ class LogController:
         for pod in pods:
             for container in pod.spec.containers:
                 if container.name not in EXCLUDE_CONTAINERS:
-                    logs = get_container_logs(pod, container)
-                    status = "Completed" if logs is not None else "Creating"
+                    logs_text = get_container_logs(pod, container)
+                    status = "Completed" if logs_text is not None else "Creating"
 
                     if container.env is None:
                         task_name = pod.metadata.name
@@ -83,7 +83,7 @@ class LogController:
                     operator_info = {
                         "status": status,
                         "containerName": task_name,
-                        "logs": self.parse_logs(logs),
+                        "logs": self.parse_logs(logs_text),
                     }
                     logs.append(operator_info)
 

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -39,13 +39,12 @@ class LogController:
         list
             A list of all logs from a run.
         """
-        # Try to retrieve any pods associated to a seldondeployment
+        # Tries to retrieve any pods associated to a seldondeployment
         pods = list_deployment_pods(deployment_id=deployment_id)
 
         if len(pods) == 0:
-            # When there aren't any seldondeployments, retrives workflow pod.
-            # This is useful for debugging in case of a failure during the
-            # workflow execution.
+            # When there aren't any seldondeployments, retrieves the workflow pods.
+            # This is useful for debugging failures during the workflow execution.
             if run_id == "latest":
                 run_id = get_latest_run_id(deployment_id)
 

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -5,7 +5,6 @@ from typing import List
 
 from io import StringIO
 
-from projects.exceptions import NotFound
 from projects.kfp.runs import get_latest_run_id
 from projects.kubernetes.argo import list_workflow_pods
 from projects.kubernetes.seldon import list_deployment_pods
@@ -16,8 +15,6 @@ EXCLUDE_CONTAINERS = ["istio-proxy", "wait", "seldon-container-engine"]
 TIME_STAMP_PATTERN = r'\d{4}-\d{2}-\d{2}(:?\s|T)\d{2}:\d{2}:\d{2}(:?.|,)\d+Z?\s?'
 LOG_MESSAGE_PATTERN = r'[a-zA-Z0-9\u00C0-\u00D6\u00D8-\u00f6\u00f8-\u00ff\"\'.\-@_,!#$%^&*()\[\]<>?\/|}{~:]{1,}'
 LOG_LEVEL_PATTERN = r'(?<![\\w\\d])INFO(?![\\w\\d])|(?<![\\w\\d])WARNING(?![\\w\\d])|(?<![\\w\\d])WARN(?![\\w\\d])|(?<![\\w\\d])ERROR(?![\\w\\d])'
-
-NOT_FOUND = NotFound("The specified run does not exist")
 
 
 class LogController:

--- a/projects/controllers/deployments/runs/logs.py
+++ b/projects/controllers/deployments/runs/logs.py
@@ -11,7 +11,7 @@ from projects.kubernetes.seldon import list_deployment_pods
 from projects.kubernetes.utils import get_container_logs
 
 
-EXCLUDE_CONTAINERS = ["istio-proxy", "seldon-container-engine"]
+EXCLUDE_CONTAINERS = ["istio-proxy", "wait", "seldon-container-engine"]
 TIME_STAMP_PATTERN = r'\d{4}-\d{2}-\d{2}(:?\s|T)\d{2}:\d{2}:\d{2}(:?.|,)\d+Z?\s?'
 LOG_MESSAGE_PATTERN = r'[a-zA-Z0-9\u00C0-\u00D6\u00D8-\u00f6\u00f8-\u00ff\"\'.\-@_,!#$%^&*()\[\]<>?\/|}{~:]{1,}'
 LOG_LEVEL_PATTERN = r'(?<![\\w\\d])INFO(?![\\w\\d])|(?<![\\w\\d])WARNING(?![\\w\\d])|(?<![\\w\\d])WARN(?![\\w\\d])|(?<![\\w\\d])ERROR(?![\\w\\d])'
@@ -55,7 +55,10 @@ class LogController:
                     logs = get_container_logs(pod, container)
                     status = "Completed" if logs is not None else "Creating"
 
-                    task_name = next((e.value for e in container.env if e.name == "TASK_NAME"), pod.metadata.name)
+                    if container.env is None:
+                        task_name = pod.metadata.name
+                    else:
+                        task_name = next((e.value for e in container.env if e.name == "TASK_NAME"), pod.metadata.name)
 
                     operator_info = {
                         "status": status,

--- a/projects/kfp/pipeline.py
+++ b/projects/kfp/pipeline.py
@@ -198,6 +198,12 @@ def create_container_op(operator, experiment_id, **kwargs):
         ) \
         .add_env_variable(
             k8s_client.V1EnvVar(
+                name="TASK_NAME",
+                value=operator.task.name,
+            ),
+        ) \
+        .add_env_variable(
+            k8s_client.V1EnvVar(
                 name="NOTEBOOK_PATH",
                 value=notebook_path,
             ),

--- a/projects/kubernetes/argo.py
+++ b/projects/kubernetes/argo.py
@@ -39,7 +39,7 @@ def list_workflows(run_id):
 
 def list_workflow_pods(run_id: str):
     """
-    Lists pods from a workflow.
+    Lists pods from a workflow. Returns only pods that ran a platiagro task.
 
     Parameters
     ----------
@@ -63,5 +63,9 @@ def list_workflow_pods(run_id: str):
         namespace=KF_PIPELINES_NAMESPACE,
         label_selector=f"workflows.argoproj.io/workflow={workflow_name}",
     ).items
+
+    # Filters by pods that have an annotation "name=...".
+    # Only pods that ran a platiagro tasks have this annotation.
+    pod_list = [pod for pod in pod_list if "name" in pod.metadata.annotations]
 
     return pod_list

--- a/projects/kubernetes/argo.py
+++ b/projects/kubernetes/argo.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Argo Workflows utility functions."""
+from kubernetes import client
+
+from projects.kfp import KF_PIPELINES_NAMESPACE
+from projects.kubernetes.kube_config import load_kube_config
+
+
+def list_workflows(run_id):
+    """
+    List workflow given a run_id.
+
+    Parameters
+    ----------
+    run_id : str
+
+    Returns
+    -------
+    list
+        A list of workflows.
+
+    Notes
+    ----
+    Equivalent to `kubectl -n KF_PIPELINES_NAMESPACE get workflow -l workflows.argoproj.io/workflow=type_-id_`.
+    """
+    load_kube_config()
+    custom_api = client.CustomObjectsApi()
+
+    workflows = custom_api.list_namespaced_custom_object(
+            group="argoproj.io",
+            version="v1alpha1",
+            namespace=KF_PIPELINES_NAMESPACE,
+            plural="workflows",
+            label_selector=f"pipeline/runid={run_id}",
+    )["items"]
+
+    return workflows
+
+
+def list_workflow_pods(run_id: str):
+    """
+    Lists pods from a workflow.
+
+    Parameters
+    ----------
+    run_id : str
+
+    Returns
+    -------
+    list
+        A list of all logs from a run.
+    """
+    workflows = list_workflows(run_id)
+    if len(workflows) == 0:
+        return []
+
+    workflow_name = workflows[0]["metadata"]["name"]
+
+    load_kube_config()
+    core_api = client.CoreV1Api()
+
+    pod_list = core_api.list_namespaced_pod(
+        namespace=KF_PIPELINES_NAMESPACE,
+        label_selector=f"workflows.argoproj.io/workflow={workflow_name}",
+    ).items
+
+    return pod_list


### PR DESCRIPTION
When a deployment fails (before seldondeployments are created),
no logs were shown.
This commit returns the logs from workflow pods since they are useful
for debugging errors.