### PR TITLE
Sends "content-type" to seldon deployment in .../predictions

### DIFF
--- a/projects/controllers/utils.py
+++ b/projects/controllers/utils.py
@@ -2,10 +2,12 @@
 """Shared functions."""
 import base64
 import csv
-import pandas
 import random
 import re
 import uuid
+
+import filetype
+import pandas
 
 
 def uuid_alpha():
@@ -76,9 +78,19 @@ def parse_file_buffer_to_seldon_request(file):
 
     except UnicodeDecodeError:
         file.seek(0)
-        bin_data = base64.b64encode(file.read()).decode("utf-8")
+        content = file.read()
+        bin_data = base64.b64encode(content).decode("utf-8")
+
+        kind = filetype.guess(content)
+        content_type = "application/octet-stream"
+        if kind is not None:
+            content_type = kind.mime
+
         return {
-            "binData": bin_data
+            "binData": bin_data,
+            "meta": {
+                "content-type": content_type,
+            },
         }
 
     except csv.Error:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ requests==2.23.0
 kfp==1.2.0
 # Kubernetes python client
 kubernetes==10.0
+# package to infer file type and MIME type
+filetype==1.0.7


### PR DESCRIPTION
Adds a new requirement:
filetype==1.0.7 - package to infer file type and MIME type

Infers the MIME type using the lib filetype, and passes it to
seldon deployment using a field in the body:
{..., "meta":{"content-type": "here-the-mime-type"}}

This is useful for tasks that receive a binary body (eg. images, audio),
but also need some metadata about the content (the MIME type).