### PR TITLE
Adds attribute "deployments" to Swagger docs

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1799,6 +1799,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Experiment"
+        deployments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Deployment"
         createdAt:
           type: string
           format: date-time


### PR DESCRIPTION
API /projects has the attribute "deployments" which wasn't mentioned.