### PR TITLE
Fix/duplicate deployment

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2048,6 +2048,8 @@ components:
         copyFrom:
           type: string
           format: uuid
+        name:
+          type: string
     Operator:
       type: object
       properties:
@@ -2557,6 +2559,7 @@ components:
               summary: From an existing deployment
               value:
                 copyFrom: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                name: string
     DeploymentPatch:
       content:
         application/json:

--- a/projects/schemas/deployment.py
+++ b/projects/schemas/deployment.py
@@ -21,6 +21,7 @@ class DeploymentCreate(DeploymentBase):
     experiments: Optional[List[str]]
     template_id: Optional[str]
     copy_from: Optional[str]
+    name: Optional[str]
 
 
 class DeploymentUpdate(DeploymentBase):

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -14,6 +14,7 @@ OPERATOR_ID = str(uuid_alpha())
 OPERATOR_ID_2 = str(uuid_alpha())
 NAME = "foo"
 NAME_2 = "bar"
+COPY_NAME = "foobar"
 DEPLOYMENT_MOCK_NAME = "Foo Deployment"
 DESCRIPTION = "long foo"
 PROJECT_ID = str(uuid_alpha())
@@ -243,8 +244,25 @@ class TestDeployments(TestCase):
         rv = TEST_CLIENT.post(f"/projects/{PROJECT_ID}/deployments", json={
             "copyFrom": DEPLOYMENT_ID,
         })
+        result = rv.json()
+        expected = {"message": "name is required to duplicate deployment"}
+        self.assertEqual(rv.status_code, 400)
+
+        rv = TEST_CLIENT.post(f"/projects/{PROJECT_ID}/deployments", json={
+            "copyFrom": DEPLOYMENT_ID,
+            "name": NAME,
+        })
+        result = rv.json()
+        expected = {"message": "a deployment with that name already exists"}
+        self.assertEqual(rv.status_code, 400)
+
+        rv = TEST_CLIENT.post(f"/projects/{PROJECT_ID}/deployments", json={
+            "copyFrom": DEPLOYMENT_ID,
+            "name": COPY_NAME,
+        })
         result = rv.json()["deployments"]
         self.assertIsInstance(result, list)
+        self.assertEqual(COPY_NAME, result[0]["name"])
         self.assertIn("operators", result[0])
         operator = result[0]["operators"][0]
         self.assertEqual(TASK_ID, operator["taskId"])


### PR DESCRIPTION
A new name is needed to duplicate experiment.
Include the name parameter on POST create_deployment when passing copyFrom.

Update Swagger docs.

Include name on unittests of create_deployment.

Runs only test_deployments.py while we are testing it.