### PR TITLE
Feature/remove resources on delete

### DIFF
--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -9,7 +9,6 @@ from projects.controllers.operators import OperatorController
 from projects.controllers.templates import TemplateController
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, NotFound
-from projects.kfp.monitorings import undeploy_monitoring
 
 NOT_FOUND = NotFound("The specified deployment does not exist")
 
@@ -211,25 +210,6 @@ class DeploymentController:
 
         if deployment is None:
             raise NOT_FOUND
-
-        # remove responses
-        self.session.query(models.Response).filter(models.Response.deployment_id == deployment_id).delete()
-
-        # remove operators
-        self.session.query(models.Operator).filter(models.Operator.deployment_id == deployment_id).delete()
-
-        # remove monitorings
-        monitorings = self.session.query(models.Monitoring).filter(models.Monitoring.deployment_id == deployment_id)
-        # Undeploy monitorings
-        if monitorings:
-            for monitoring in monitorings:
-                self.background_tasks.add_task(
-                    undeploy_monitoring,
-                    monitoring_id=monitoring.uuid
-                )
-
-        # delete monitorings on database
-        monitorings.delete()
 
         self.session.delete(deployment)
 

--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from projects import models, schemas
 from projects.controllers.experiments import ExperimentController
 from projects.controllers.operators import OperatorController
-from projects.controllers.deployments.runs import RunController
 from projects.controllers.templates import TemplateController
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, NotFound
@@ -20,7 +19,6 @@ class DeploymentController:
         self.session = session
         self.experiment_controller = ExperimentController(session)
         self.operator_controller = OperatorController(session)
-        self.run_controller = RunController(session)
         self.template_controller = TemplateController(session)
         self.background_tasks = background_tasks
 
@@ -238,16 +236,6 @@ class DeploymentController:
         self.fix_positions(project_id=project_id)
 
         self.session.commit()
-
-        try:
-            self.run_controller.terminate_run(
-                project_id=project_id,
-                deployment_id=deployment_id,
-                run_id="latest"
-            )
-        except NotFound:
-            # we can ignore this exception
-            pass
 
         return schemas.Message(message="Deployment deleted")
 

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -149,15 +149,13 @@ class RunController:
 
         return run
 
-    def terminate_run(self, project_id, deployment_id, run_id):
+    def terminate_run(self, deployment_id):
         """
         Terminates a run in Kubeflow Pipelines.
 
         Parameters
         ----------
-        project_id : str
         deployment_id : str
-        run_id : str
 
         Returns
         -------
@@ -166,7 +164,7 @@ class RunController:
         Raises
         ------
         NotFound
-            When any of project_id, deployment_id, or run_id does not exist.
+            When deployment run does not exist.
         """
         load_kube_config()
         api = client.CustomObjectsApi()

--- a/projects/models/deployment.py
+++ b/projects/models/deployment.py
@@ -29,9 +29,6 @@ class Deployment(Base):
                              primaryjoin=uuid == Operator.deployment_id,
                              lazy="joined",
                              cascade=CASCADE)
-    responses = relationship("Response",
-                             primaryjoin=uuid == Response.deployment_id,
-                             cascade=CASCADE)
     monitorings = relationship("Monitoring",
                                primaryjoin=uuid == Monitoring.deployment_id,
                                cascade=CASCADE)

--- a/projects/models/deployment.py
+++ b/projects/models/deployment.py
@@ -15,6 +15,8 @@ from projects.models.monitoring import Monitoring
 from projects.models.operator import Operator
 from projects.models.response import Response
 
+CASCADE = "all, delete-orphan"
+
 
 class Deployment(Base):
     __tablename__ = "deployments"
@@ -26,13 +28,13 @@ class Deployment(Base):
     operators = relationship("Operator",
                              primaryjoin=uuid == Operator.deployment_id,
                              lazy="joined",
-                             cascade="all, delete-orphan")
+                             cascade=CASCADE)
     responses = relationship("Response",
                              primaryjoin=uuid == Response.deployment_id,
-                             cascade="all, delete-orphan")
+                             cascade=CASCADE)
     monitorings = relationship("Monitoring",
                                primaryjoin=uuid == Monitoring.deployment_id,
-                               cascade="all, delete-orphan")
+                               cascade=CASCADE)
     position = Column(Integer, nullable=False, default=-1)
     status = Column(String(255), nullable=False, default="Pending")
     url = Column(String(255), nullable=True)

--- a/projects/models/deployment.py
+++ b/projects/models/deployment.py
@@ -2,10 +2,12 @@
 """Deployment model."""
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, ForeignKey
+from sqlalchemy import Boolean, Column, DateTime, event, \
+    Integer, String, Text, ForeignKey
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
+from projects.controllers.deployments.runs import RunController
 from projects.database import Base
 from projects.models.operator import Operator
 from projects.models.response import Response
@@ -31,3 +33,8 @@ class Deployment(Base):
     deployed_at = Column(DateTime, nullable=True)
     project_id = Column(String(255), ForeignKey("projects.uuid"), nullable=False, index=True)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+@event.listens_for(Deployment, "after_delete")
+def undeploy(_mapper, connection, target):
+    RunController(connection).terminate_run(deployment_id=target.uuid)

--- a/projects/models/monitoring.py
+++ b/projects/models/monitoring.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """Monitoring model."""
 from datetime import datetime
+from warnings import warn
 
-from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy import Column, DateTime, event, \
+    ForeignKey, String
 from sqlalchemy.orm import relationship
 
 from projects.database import Base
+from projects.exceptions import NotFound
+from projects.kfp import monitorings
 
 
 class Monitoring(Base):
@@ -15,3 +19,11 @@ class Monitoring(Base):
     task_id = Column(String(255), ForeignKey("tasks.uuid"), nullable=False, index=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     task = relationship("Task")
+
+
+@event.listens_for(Monitoring, "after_delete")
+def undeploy(_mapper, _connection, target):
+    try:
+        monitorings.undeploy_monitoring(monitoring_id=target.uuid)
+    except NotFound as e:
+        warn(e.message)

--- a/projects/models/response.py
+++ b/projects/models/response.py
@@ -10,6 +10,6 @@ from projects.database import Base
 class Response(Base):
     __tablename__ = "responses"
     uuid = Column(String(255), primary_key=True)
-    deployment_id = Column(String(255), ForeignKey("deployments.uuid"), nullable=False, index=True)
+    deployment_id = Column(String(255), nullable=False, index=True)
     body = Column(JSON, nullable=False, default={})
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)


### PR DESCRIPTION
Add SQLAlchemy event listener to watch for DELETE queries on deployments and monitorings.
The listener will undeploy sdep and monitoring resources (service, trigger) after a DELETE statement.