### PR TITLE
Fix parsing of logs with multiple lines

### DIFF
--- a/projects/controllers/logs/logs.py
+++ b/projects/controllers/logs/logs.py
@@ -162,9 +162,15 @@ class LogController:
                 except (ValueError, OverflowError):
                     pass
             else:
-                # this is necessary to remove kubernetes timestamps
-                # of the lines in the message body
-                message_lines.append(line.split(' ', 1)[1])
+                # This is necessary to remove kubernetes timestamps
+                # of the lines in the message body. This regex will
+                # look for timestamp at the beginning of line.
+                line = re.sub(
+                    r"^([0-9]{4}(-[0-9]{2}){2}T[0-9]{2}(:[0-9]{2}){2}.[0-9]+Z\s)",
+                    "", line, 2
+                )
+
+                message_lines.append(line)
 
             line = buffer.readline()
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -144,7 +144,7 @@ class TestLogs(TestCase):
         expected = {
             "level": "INFO",
             "title": NAME,
-            "message": "hello",
+            "message": "hello\nhello",
         }
         # title and created_at are machine-generated
         # we assert they exist, but we don't assert their values


### PR DESCRIPTION
- Fix regex to match only lines that include log level
- Remove timestamps from lines of message body