### PR TITLE
Fix format_query_params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
         pip install pytest pytest-cov
         platiagro-init-db
         coverage erase
-        coverage run --branch --source=projects -m pytest tests/test_api.py tests/test_comparisons.py tests/test_database.py tests/test_deployments_runs.py tests/test_deployments.py tests/test_experiments_runs.py tests/test_experiments.py tests/test_logs.py tests/test_monitorings.py tests/test_operators.py tests/test_parameters.py tests/test_tasks.py tests/test_templates.py
+        coverage run --branch --source=projects -m pytest tests/test_api.py tests/test_comparisons.py tests/test_database.py tests/test_deployments_runs.py tests/test_deployments.py tests/test_experiments_runs.py tests/test_experiments.py tests/test_logs.py tests/test_monitorings.py tests/test_operators.py tests/test_parameters.py tests/test_projects.py tests/test_tasks.py tests/test_templates.py
         coverage xml -i
       env:
         MINIO_ENDPOINT: localhost:9000

--- a/projects/api/projects.py
+++ b/projects/api/projects.py
@@ -30,7 +30,6 @@ async def handle_list_projects(request: Request,
     -------
     projects.schemas.project.ProjectList
     """
-    project_controller = ProjectController(session)
     filters = format_query_params(str(request.query_params))
     order_by = filters.pop("order", None)
     page = filters.pop("page", 1)
@@ -39,6 +38,8 @@ async def handle_list_projects(request: Request,
     page_size = filters.pop("page_size", 10)
     if page_size:
         page_size = int(page_size)
+
+    project_controller = ProjectController(session)
     projects = project_controller.list_projects(page=page,
                                                 page_size=page_size,
                                                 order_by=order_by,

--- a/projects/api/projects.py
+++ b/projects/api/projects.py
@@ -31,13 +31,14 @@ async def handle_list_projects(request: Request,
     projects.schemas.project.ProjectList
     """
     filters = format_query_params(str(request.query_params))
+
     order_by = filters.pop("order", None)
+
     page = filters.pop("page", 1)
-    if page:
-        page = int(page)
-    page_size = filters.pop("page_size", 10)
-    if page_size:
-        page_size = int(page_size)
+    page = int(page) if page else 1
+
+    page_size = filters.pop("page_size", None)
+    page_size = int(page_size) if page_size else 10
 
     project_controller = ProjectController(session)
     projects = project_controller.list_projects(page=page,

--- a/projects/controllers/projects.py
+++ b/projects/controllers/projects.py
@@ -81,7 +81,7 @@ class ProjectController:
 
         # Sorts records
         try:
-            (column, sort) = order_by.replace('+', ' ').strip().split()
+            (column, sort) = order_by.strip().split()
             assert sort.lower() in ["asc", "desc"]
             assert column in models.Project.__table__.columns.keys()
         except (AssertionError, ValueError):
@@ -115,9 +115,6 @@ class ProjectController:
         BadRequest
             When the project attributes are invalid.
         """
-        if not isinstance(project.name, str):
-            raise BadRequest("name is required")
-
         store_project = self.session.query(models.Project) \
             .filter_by(name=project.name) \
             .first()

--- a/projects/controllers/projects.py
+++ b/projects/controllers/projects.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from os.path import join
 from typing import Optional
 
-from sqlalchemy import asc, desc, func
+from sqlalchemy import asc, desc, func, collate
 
 from projects import models, schemas
 from projects.controllers.experiments import ExperimentController
@@ -70,8 +70,8 @@ class ProjectController:
         query_total = self.session.query(func.count(models.Project.uuid))
 
         for column, value in filters.items():
-            query = query.filter(getattr(models.Project, column).ilike(f"%{value}%"))
-            query_total = query_total.filter(getattr(models.Project, column).ilike(f"%{value}%"))
+            query = query.filter(getattr(models.Project, column).ilike(f"%{value}%").collate("utf8mb4_bin"))
+            query_total = query_total.filter(getattr(models.Project, column).ilike(f"%{value}%").collate("utf8mb4_bin"))
 
         total = query_total.scalar()
 

--- a/projects/utils.py
+++ b/projects/utils.py
@@ -2,6 +2,7 @@
 """Utility functions."""
 import re
 from itertools import chain
+from urllib.parse import parse_qsl
 
 
 def to_camel_case(snake_str):
@@ -69,9 +70,4 @@ def format_query_params(query_params):
     -------
     dict
     """
-    params = {}
-    if query_params:
-        for query_param in query_params.split('&'):
-            splited = query_param.split('=')
-            params[splited[0]] = splited[1]
-    return params
+    return dict(parse_qsl(query_params))

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -259,7 +259,6 @@ class TestExperiments(TestCase):
         self.assertEqual(rv.status_code, 404)
 
         rv = TEST_CLIENT.post(f"/projects/{PROJECT_ID}/experiments", json={})
-        result = rv.json()
         self.assertEqual(rv.status_code, 422)
 
         rv = TEST_CLIENT.post(f"/projects/{PROJECT_ID}/experiments", json={


### PR DESCRIPTION
Query params with invalid characters, such as whitespaces, are not returning the expected result.
Now format_query_params is using urllib.parse.parse_qsl, this automatically parses the query parameters string to dict and eliminates invalid characters.
Change ilike comparison encoding to verify accents.