### PR TITLE
On create_deployment start a new deployment run

### DIFF
--- a/projects/api/deployments/runs/runs.py
+++ b/projects/api/deployments/runs/runs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Runs API Router."""
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from projects.controllers import DeploymentController, ProjectController
@@ -36,15 +36,13 @@ async def handle_list_runs(project_id: str,
     deployment_controller.raise_if_deployment_does_not_exist(deployment_id)
 
     run_controller = RunController(session)
-    runs = run_controller.list_runs(project_id=project_id,
-                                    deployment_id=deployment_id)
+    runs = run_controller.list_runs(deployment_id=deployment_id)
     return runs
 
 
 @router.post("")
 async def handle_post_runs(project_id: str,
                            deployment_id: str,
-                           background_tasks: BackgroundTasks,
                            session: Session = Depends(session_scope)):
     """
     Handles POST requests to /.
@@ -65,9 +63,8 @@ async def handle_post_runs(project_id: str,
     deployment_controller = DeploymentController(session)
     deployment_controller.raise_if_deployment_does_not_exist(deployment_id)
 
-    run_controller = RunController(session, background_tasks)
-    run = run_controller.create_run(project_id=project_id,
-                                    deployment_id=deployment_id)
+    run_controller = RunController(session)
+    run = run_controller.create_run(deployment_id=deployment_id)
     return run
 
 
@@ -97,9 +94,7 @@ async def handle_get_run(project_id: str,
     deployment_controller.raise_if_deployment_does_not_exist(deployment_id)
 
     run_controller = RunController(session)
-    run = run_controller.get_run(project_id=project_id,
-                                 deployment_id=deployment_id,
-                                 run_id=run_id)
+    run = run_controller.get_run(deployment_id=deployment_id)
     return run
 
 

--- a/projects/api/monitorings/monitorings.py
+++ b/projects/api/monitorings/monitorings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Monitorings API Router."""
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 from sqlalchemy.orm import Session
 
 import projects.schemas.monitoring
@@ -37,8 +37,7 @@ async def handle_list_monitorings(project_id: str,
     deployment_controller.raise_if_deployment_does_not_exist(deployment_id)
 
     monitoring_controller = MonitoringController(session)
-    monitorings = monitoring_controller.list_monitorings(project_id=project_id,
-                                                         deployment_id=deployment_id)
+    monitorings = monitoring_controller.list_monitorings(deployment_id=deployment_id)
     return monitorings
 
 
@@ -46,6 +45,7 @@ async def handle_list_monitorings(project_id: str,
 async def handle_post_monitorings(project_id: str,
                                   deployment_id: str,
                                   monitoring: projects.schemas.monitoring.MonitoringCreate,
+                                  background_tasks: BackgroundTasks,
                                   session: Session = Depends(session_scope)):
     """
     Handles POST requests to /.
@@ -67,9 +67,8 @@ async def handle_post_monitorings(project_id: str,
     deployment_controller = DeploymentController(session)
     deployment_controller.raise_if_deployment_does_not_exist(deployment_id)
 
-    monitoring_controller = MonitoringController(session)
-    monitoring = monitoring_controller.create_monitoring(project_id=project_id,
-                                                         deployment_id=deployment_id,
+    monitoring_controller = MonitoringController(session, background_tasks)
+    monitoring = monitoring_controller.create_monitoring(deployment_id=deployment_id,
                                                          monitoring=monitoring)
     return monitoring
 
@@ -100,7 +99,5 @@ async def handle_delete_monitorings(project_id: str,
     deployment_controller.raise_if_deployment_does_not_exist(deployment_id)
 
     monitoring_controller = MonitoringController(session)
-    response = monitoring_controller.delete_monitoring(uuid=monitoring_id,
-                                                       project_id=project_id,
-                                                       deployment_id=deployment_id)
+    response = monitoring_controller.delete_monitoring(uuid=monitoring_id)
     return response

--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -116,7 +116,7 @@ class DeploymentController:
 
         self.session.commit()
         for deployment in deployments:
-            self.run_controller.create_run(deployment_id=deployment.uuid)
+            self.run_controller.deploy_run(deployment_id=deployment.uuid)
             self.session.refresh(deployment)
 
         return schemas.DeploymentList.from_orm(deployments, len(deployments))

--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -116,8 +116,7 @@ class DeploymentController:
 
         self.session.commit()
         for deployment in deployments:
-            self.run_controller.create_run(project_id=project_id,
-                                           deployment_id=deployment.uuid)
+            self.run_controller.create_run(deployment_id=deployment.uuid)
             self.session.refresh(deployment)
 
         return schemas.DeploymentList.from_orm(deployments, len(deployments))

--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -4,6 +4,7 @@ import sys
 from datetime import datetime
 
 from projects import models, schemas
+from projects.controllers.deployments.runs import RunController
 from projects.controllers.experiments import ExperimentController
 from projects.controllers.operators import OperatorController
 from projects.controllers.templates import TemplateController
@@ -18,6 +19,7 @@ class DeploymentController:
         self.session = session
         self.experiment_controller = ExperimentController(session)
         self.operator_controller = OperatorController(session)
+        self.run_controller = RunController(session)
         self.template_controller = TemplateController(session)
         self.background_tasks = background_tasks
 
@@ -114,6 +116,8 @@ class DeploymentController:
 
         self.session.commit()
         for deployment in deployments:
+            self.run_controller.create_run(project_id=project_id,
+                                           deployment_id=deployment.uuid)
             self.session.refresh(deployment)
 
         return schemas.DeploymentList.from_orm(deployments, len(deployments))

--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -398,7 +398,7 @@ class DeploymentController:
 
             if stored_operator.task.category == "DATASETS":
                 name = FONTE_DE_DADOS
-                parameters = {"type": "L"}
+                parameters = {"type": "L", "dataset": None}
                 some_stored_operators_is_dataset = True
             else:
                 name = None
@@ -432,7 +432,7 @@ class DeploymentController:
                 name=FONTE_DE_DADOS,
                 task_id=self.task_controller.get_or_create_dataset_task_if_not_exist(),
                 deployment_id=deployment_id,
-                parameters={"type": "L"},
+                parameters={"type": "L", "dataset": None},
                 position_x=leftmost_operator_position[0] - DATASET_OPERATOR_DISTANCE,
                 position_y=leftmost_operator_position[1],
             )

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -80,17 +80,18 @@ class RunController:
 
         run = self.get_run(deployment_id)
 
-        operators = dict((o.uuid, {"deploymentId": deployment_id, "parameters": {}}) for o in deployment.operators)
-
         # Uses empty run if a deployment does not have a run
         if not run:
+            operators = dict((o.uuid, {"taskId": o.task.uuid, "parameters": {}}) for o in deployment.operators)
             run = {
                 "uuid": "",
                 "operators": operators,
                 "createdAt": deployment.created_at,
             }
 
-        return schemas.Run.from_orm(run)
+        run["deploymentId"] = deployment_id
+
+        return run
 
     def deploy_run(self, deployment_id: str):
         """

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -64,7 +64,7 @@ class RunController:
 
         Returns
         -------
-        projects.schemas.deployment.Deployment
+        projects.schemas.run.Run
 
         Raises
         ------
@@ -78,7 +78,19 @@ class RunController:
             .update({"url": url})
         self.session.commit()
 
-        return schemas.Deployment.from_orm(deployment)
+        run = self.get_run(deployment_id)
+
+        operators = dict((o.uuid, {"deploymentId": deployment_id, "parameters": {}}) for o in deployment.operators)
+
+        # Uses empty run if a deployment does not have a run
+        if not run:
+            run = {
+                "uuid": "",
+                "operators": operators,
+                "createdAt": deployment.created_at,
+            }
+
+        return schemas.Run.from_orm(run)
 
     def deploy_run(self, deployment_id: str):
         """

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -73,7 +73,9 @@ class RunController:
         """
         deployment = self.session.query(models.Deployment).get(deployment_id)
         url = get_seldon_deployment_url(deployment_id)
-        deployment.update({"url": url})
+        self.session.query(models.Deployment) \
+            .filter_by(uuid=deployment_id) \
+            .update({"url": url})
         self.session.commit()
 
         return schemas.Deployment.from_orm(deployment)

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -56,6 +56,30 @@ class RunController:
 
     def create_run(self, deployment_id: str):
         """
+        Update deployment url.
+
+        Parameters
+        ----------
+        deployment_id : str
+
+        Returns
+        -------
+        projects.schemas.deployment.Deployment
+
+        Raises
+        ------
+        NotFound
+            When any of project_id, or deployment_id does not exist.
+        """
+        deployment = self.session.query(models.Deployment).get(deployment_id)
+        url = get_seldon_deployment_url(deployment_id)
+        deployment.update({"url": url})
+        self.session.commit()
+
+        return schemas.Deployment.from_orm(deployment)
+
+    def deploy_run(self, deployment_id: str):
+        """
         Starts a new run in Kubeflow Pipelines.
 
         Parameters
@@ -94,13 +118,7 @@ class RunController:
         for operator in deployment.operators:
             self.session.expunge(operator)
 
-        url = get_seldon_deployment_url(deployment_id)
-        self.session.query(models.Deployment) \
-            .filter_by(uuid=deployment_id) \
-            .update({"url": url})
-        self.session.commit()
-
-        return run
+        return schemas.Run.from_orm(run)
 
     def get_run(self, deployment_id: str):
         """

--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -89,7 +89,7 @@ class MonitoringController:
             deploy_monitoring,
             deployment_id=deployment_id,
             experiment_id=deployment.experiment_id,
-            run_id=run.uuid,
+            run_id=run["uuid"],
             task_id=monitoring.task_id,
             monitoring_id=monitoring.uuid
         )

--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -85,7 +85,7 @@ class MonitoringController:
         deployment = self.session.query(models.Deployment).get(deployment_id)
         run = self.run_controller.get_run(deployment_id)
 
-        self.background_task.add_task(
+        self.background_tasks.add_task(
             deploy_monitoring,
             deployment_id=deployment_id,
             experiment_id=deployment.experiment_id,

--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -86,14 +86,14 @@ class MonitoringController:
 
         # Uses empty run_id if a deployment does not have a run
         if not run:
-            run = {"uuid": ""}
+            run = {"runId": ""}
 
         # Deploy the new monitoring
         self.background_tasks.add_task(
             deploy_monitoring,
             deployment_id=deployment_id,
             experiment_id=deployment.experiment_id,
-            run_id=run["uuid"],
+            run_id=run["runId"],
             task_id=monitoring.task_id,
             monitoring_id=monitoring.uuid
         )

--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -1,17 +1,21 @@
 # -*- coding: utf-8 -*-
 """Monitorings controller."""
 from projects import models, schemas
+from projects.controllers.deployments.runs.runs import RunController
 from projects.controllers.tasks import TaskController
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import NotFound
+from projects.kfp.monitorings import deploy_monitoring
 
 
 NOT_FOUND = NotFound("The specified monitoring does not exist")
 
 
 class MonitoringController:
-    def __init__(self, session):
+    def __init__(self, session, background_tasks=None):
         self.session = session
+        self.background_tasks = background_tasks
+        self.run_controller = RunController(session)
         self.task_controller = TaskController(session)
 
     def raise_if_monitoring_does_not_exist(self, monitoring_id: str):
@@ -33,13 +37,12 @@ class MonitoringController:
         if not exists:
             raise NotFound("The specified monitoring does not exist")
 
-    def list_monitorings(self, project_id: str, deployment_id: str):
+    def list_monitorings(self, deployment_id: str):
         """
         Lists all monitorings under a deployment.
 
         Parameters
         ----------
-        project_id : str
         deployment_id : str
 
         Returns
@@ -53,7 +56,7 @@ class MonitoringController:
 
         return schemas.MonitoringList.from_orm(monitorings, len(monitorings))
 
-    def create_monitoring(self, monitoring: schemas.MonitoringCreate, project_id: str, deployment_id: str):
+    def create_monitoring(self, monitoring: schemas.MonitoringCreate, deployment_id: str):
         """
         Creates a new monitoring in our database.
 
@@ -78,17 +81,28 @@ class MonitoringController:
         self.session.commit()
         self.session.refresh(monitoring)
 
+        # Deploy the new monitoring
+        deployment = self.session.query(models.Deployment).get(deployment_id)
+        run = self.run_controller.get_run(deployment_id)
+
+        self.background_task.add_task(
+            deploy_monitoring,
+            deployment_id=deployment_id,
+            experiment_id=deployment.experiment_id,
+            run_id=run.uuid,
+            task_id=monitoring.task_id,
+            monitoring_id=monitoring.uuid
+        )
+
         return schemas.Monitoring.from_orm(monitoring)
 
-    def delete_monitoring(self, uuid, project_id, deployment_id):
+    def delete_monitoring(self, uuid):
         """
         Delete a monitoring in our database.
 
         Parameters
         ----------
         uuid : str
-        project_id : str
-        deployment_id : str
 
         Returns
         -------

--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -81,10 +81,14 @@ class MonitoringController:
         self.session.commit()
         self.session.refresh(monitoring)
 
-        # Deploy the new monitoring
         deployment = self.session.query(models.Deployment).get(deployment_id)
         run = self.run_controller.get_run(deployment_id)
 
+        # Uses empty run_id if a deployment does not have a run
+        if not run:
+            run = {"uuid": ""}
+
+        # Deploy the new monitoring
         self.background_tasks.add_task(
             deploy_monitoring,
             deployment_id=deployment_id,

--- a/tests/test_deployments_runs.py
+++ b/tests/test_deployments_runs.py
@@ -179,13 +179,6 @@ class TestDeploymentsRuns(TestCase):
         self.assertEqual(rv.status_code, 404)
         self.assertDictEqual(result, expected)
 
-        rv = TEST_CLIENT.post(f"/projects/{PROJECT_ID}/deployments/{DEPLOYMENT_ID_2}/runs", json={})
-        result = rv.json()
-        expected = {"message": "Necessary at least one operator"}
-        self.assertIsInstance(result, dict)
-        self.assertEqual(rv.status_code, 400)
-        self.assertDictEqual(result, expected)
-
         rv = TEST_CLIENT.post(f"/projects/{PROJECT_ID}/deployments/{DEPLOYMENT_ID}/runs")
         result = rv.json()
         self.assertIsInstance(result, dict)


### PR DESCRIPTION
This is a workaround to allow the user to test the deployment pipeline before deploying manually.