### PR TITLE
Adapts workflow watcher to latest Argo Workflows responses

### DIFF
--- a/projects/agent/watchers/workflow.py
+++ b/projects/agent/watchers/workflow.py
@@ -126,10 +126,17 @@ def update_status(workflow_manifest, session):
         # Maps Workflow status to values that are supported by the frontend
         status = WORKFLOW_STATUSES.get(status, status)
 
-        if key == "experiment" and status_message not in RECURRENT_MESSAGES:
-            session.query(models.Operator) \
-                .filter_by(uuid=operator_id) \
-                .update({"status": status, "status_message": status_message})
+        update_values = {}
+
+        if status_message not in RECURRENT_MESSAGES:
+            update_values.update({"status_message": status_message})
+
+        if key == "experiment":
+            update_values.update({"status": status})
+
+        session.query(models.Operator) \
+            .filter_by(uuid=operator_id) \
+            .update(update_values)
 
     session.commit()
 

--- a/projects/agent/watchers/workflow.py
+++ b/projects/agent/watchers/workflow.py
@@ -94,24 +94,10 @@ def update_status(workflow_manifest, session):
     workflow_manifest : dict
     session : sqlalchemy.orm.session.Session
     """
-    # First, we set the status for operators that are unlisted in object.status.nodes.
-    # Obs: the workflow manifest contains only the nodes that are ready to run (whose dependencies succeeded)
-
-    # if the workflow is pending/running, then unlisted_operators_status = "Pending"
-    # if the workflow succeeded/failed, then unlisted_operators_status = "Unset/Setted Up"
-    workflow_status = workflow_manifest["object"]["status"].get("phase")
-    if workflow_status in {"Pending", "Running"}:
-        unlisted_operators_status = "Pending"
-    else:
-        unlisted_operators_status = "Unset"
-
     match = re.search(r"(experiment|deployment)-(.*)-\w+", workflow_manifest["object"]["metadata"]["name"])
     if match:
         key = match.group(1)
         id_ = match.group(2)
-        session.query(models.Operator) \
-            .filter_by(**{f"{key}_id": id_}) \
-            .update({"status": unlisted_operators_status})
 
         # check if this workflow is a deployment
         if key == "deployment":
@@ -140,7 +126,7 @@ def update_status(workflow_manifest, session):
         # Maps Workflow status to values that are supported by the frontend
         status = WORKFLOW_STATUSES.get(status, status)
 
-        if status_message not in RECURRENT_MESSAGES:
+        if key == "experiment" and status_message not in RECURRENT_MESSAGES:
             session.query(models.Operator) \
                 .filter_by(uuid=operator_id) \
                 .update({"status": status, "status_message": status_message})


### PR DESCRIPTION
Removes logic that set status = 'Unset' for operators that were not
listed. Latest Argo, now lists all nodes, and the ones that did start
run have status = 'Omitted'. We translate 'Omitted' to 'Failed'.