### PR TITLE
Set status of deployment operators to Setted up

### DIFF
--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -308,6 +308,7 @@ class DeploymentController:
                     dependencies=dependencies,
                     position_x=task["position_x"],
                     position_y=task["position_y"],
+                    status="Setted up"
                 )
             ]
             self.session.bulk_save_objects(objects)

--- a/projects/controllers/operators/operators.py
+++ b/projects/controllers/operators/operators.py
@@ -112,6 +112,7 @@ class OperatorController:
                                    deployment_id=deployment_id,
                                    task_id=operator.task_id,
                                    dependencies=operator.dependencies,
+                                   status=operator.status,
                                    parameters=operator.parameters,
                                    position_x=operator.position_x,
                                    position_y=operator.position_y)

--- a/projects/schemas/operator.py
+++ b/projects/schemas/operator.py
@@ -23,6 +23,7 @@ class OperatorCreate(OperatorBase):
     position_x: int
     position_y: int
     dependencies: Optional[List[str]]
+    status: Optional[str]
 
 
 class OperatorUpdate(OperatorBase):


### PR DESCRIPTION
No longer update updates status of deployment operators. Set the default for these operators to "Setted up".