### PR TITLE
Sets kubernetes==12.0.1 in requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ RUN pip install -r /app/requirements.txt
 COPY ./projects /app/projects
 COPY ./setup.py /app/setup.py
 
-RUN pip install /app/ && \
-    pip install --force-reinstall "kubernetes==12.0.1"
+RUN pip install /app/
 
 WORKDIR /app/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ PyMySQL==1.0.2
 # Kubeflow Pipelines SDK
 kfp==1.6.6
 # Kubernetes python client
-kubernetes==10.0
+kubernetes==12.0.1
 # package to infer file type and MIME type
 filetype==1.0.7
 # HTTP library


### PR DESCRIPTION
kfp was updated and there is no longer a conflict of kubernetes sdk versions.
We can set kubernetes==12.0.1 in requirements.txt and install all libs in
one step (and remove extra pip install from Dockerfile).

Kubernetes SDK 12.0.1 is required in order to read and write bytes when
executing commands on containers. The previous SDK version (10) allowed
only to send/receive str.