### PR TITLE
[PROJECTS] API EventSource para operators

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,17 +10,16 @@ services:
       - minio
     ports:
       - ${CONTAINER_PORT:-8080}:${HOST_PORT:-8080}
-    command: ["--init-db", "--enable-cors"]
+    command: ["--host", "0.0.0.0","--port","8080"]
     environment:
       - MYSQL_DB_HOST=mysql
       - MYSQL_DB_NAME=platiagro
       - MYSQL_DB_USER=root
       - MYSQL_DB_PASSWORD=
       - MINIO_ENDPOINT=minio-service:9000
-      - MINIO_ACCESS_KEY=minio
-      - MINIO_SECRET_KEY=minio123
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio123
       - MINIO_REGION_NAME=us-east-1
-      - MINIO_REGION_NAME=
       - JUPYTER_ENDPOINT=http://jupyter:8888
 
   db:
@@ -43,8 +42,8 @@ services:
     ports:
       - "${MINIO_PORT:-9000}:9000"
     environment:
-      MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY:-minio}"
-      MINIO_SECRET_KEY: "${MINIO_SECRET_KEY:-minio123}"
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:-minio}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:-minio123}"
     command: server /data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://minio:9000/minio/health/live"]

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1266,32 +1266,32 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
   /projects/{projectId}/deployments/{deploymentId}/logs/eventsource:
-    get:
-        summary: "Server sent events of log stream of pods used in the given deployment."
-        tags:
-          - "Deployments"
-        parameters:
-          - in: path
-            name: projectId
-            required: true
-            schema:
-              type: string
-              format: uuid
-          - in: path
-            name: deploymentId
-            required: true
-            schema:
-              type: string
-              format: uuid
-        responses:
-          "200":
-            description: "Returns log stream"
-          "400":
-            $ref: "#/components/responses/BadRequest"
-          "500":
-            $ref: "#/components/responses/InternalServerError"
-          "503":
-            $ref: "#/components/responses/ServiceUnavailable"
+   get:
+       summary: "Server sent events of log stream of pods used in the given deployment."
+       tags:
+         - "Deployments"
+       parameters:
+         - in: path
+           name: projectId
+           required: true
+           schema:
+             type: string
+             format: uuid
+         - in: path
+           name: deploymentId
+           required: true
+           schema:
+             type: string
+             format: uuid
+       responses:
+         "200":
+           description: "Returns log stream"
+         "400":
+           $ref: "#/components/responses/BadRequest"
+         "500":
+           $ref: "#/components/responses/InternalServerError"
+         "503":
+           $ref: "#/components/responses/ServiceUnavailable"
   /projects/{projectId}/deployments/{deploymentId}/operators:
     get:
       summary: "List all operators, unsorted."

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -662,6 +662,27 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+  /projects/{projectId}/experiments/{experimentId}/operators/eventsource:
+    get:
+      summary: "Server sent events of log stream of pods used in the given experiment."
+      tags:
+        - "Experiment Operators"
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: "Returns log stream"
   /projects/{projectId}/experiments/{experimentId}/operators/{operatorId}:
     patch:
       summary: "Update an operator by ID."

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -578,6 +578,33 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+  /projects/{projectId}/experiments/{experimentId}/logs/eventsource:
+    get:
+        summary: "Server sent events of log stream of pods used in the given experiment."
+        tags:
+          - "Experiments"
+        parameters:
+          - name: projectId
+            in: path
+            required: true
+            schema:
+              type: string
+              format: uuid
+          - name: experimentId
+            in: path
+            required: true
+            schema:
+              type: string
+              format: uuid
+        responses:
+          "200":
+            description: "Returns log stream"
+          "400":
+            $ref: "#/components/responses/BadRequest"
+          "500":
+            $ref: "#/components/responses/InternalServerError"
+          "503":
+            $ref: "#/components/responses/ServiceUnavailable"
   /projects/{projectId}/experiments/{experimentId}/operators:
     get:
       summary: "List all operators, unsorted."
@@ -1238,6 +1265,33 @@ paths:
           $ref: "#/components/responses/InternalServerError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+  /projects/{projectId}/deployments/{deploymentId}/logs/eventsource:
+    get:
+        summary: "Server sent events of log stream of pods used in the given deployment."
+        tags:
+          - "Deployments"
+        parameters:
+          - in: path
+            name: projectId
+            required: true
+            schema:
+              type: string
+              format: uuid
+          - in: path
+            name: deploymentId
+            required: true
+            schema:
+              type: string
+              format: uuid
+        responses:
+          "200":
+            description: "Returns log stream"
+          "400":
+            $ref: "#/components/responses/BadRequest"
+          "500":
+            $ref: "#/components/responses/InternalServerError"
+          "503":
+            $ref: "#/components/responses/ServiceUnavailable"
   /projects/{projectId}/deployments/{deploymentId}/operators:
     get:
       summary: "List all operators, unsorted."

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -664,7 +664,7 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
   /projects/{projectId}/experiments/{experimentId}/operators/eventsource:
     get:
-      summary: "Server sent events of log stream of pods used in the given experiment."
+      summary: "Server sent events of operator's status change stream."
       tags:
         - "Experiment Operators"
       parameters:

--- a/projects/api/deployments/deployments.py
+++ b/projects/api/deployments/deployments.py
@@ -2,7 +2,7 @@
 """Deployments API Router."""
 from typing import Optional
 from sse_starlette.sse import EventSourceResponse
-from fastapi import APIRouter, BackgroundTasks, Request, Depends, Header 
+from fastapi import APIRouter, BackgroundTasks, Request, Depends, Header
 from sqlalchemy.orm import Session
 
 import projects.schemas.deployment
@@ -172,10 +172,10 @@ async def handle_log_deployment(deployment_id: str,
     """
     pods = list_deployment_pods(deployment_id)
     if len(pods) == 1:
-        pod=pods[0].metadata.name
-        namespace=pods[0].metadata.namespace
-        container=pods[0].spec.containers[0].name
-        stream = log_stream(req,pod,namespace,container)
+        pod = pods[0].metadata.name
+        namespace = pods[0].metadata.namespace
+        container = pods[0].spec.containers[0].name
+        stream = log_stream(req, pod, namespace, container)
         return EventSourceResponse(stream)
     elif len(pods) == 0:
         return "unable to create log stream"

--- a/projects/api/deployments/deployments.py
+++ b/projects/api/deployments/deployments.py
@@ -168,10 +168,6 @@ async def handle_log_deployment(deployment_id: str,
     -------
     EventSourceResponse
     """
-    print(deployment_id)
     controller = LogController()
     stream = controller.event_logs(req, deployment_id)
-    if stream:
-        return EventSourceResponse(stream)
-    else:
-        return "unable to create log stream"
+    return EventSourceResponse(stream)

--- a/projects/api/deployments/deployments.py
+++ b/projects/api/deployments/deployments.py
@@ -154,20 +154,18 @@ async def handle_delete_deployment(project_id: str,
 
 
 @router.get("/{deployment_id}/logs/eventsource")
-async def handle_log_deployment(deployment_id: str,
-                                req: Request):
+async def handle_log_deployment(deployment_id: str):
     """
     Handles log event source requests to /<deployment_id>/logs/eventsource.
 
     Parameters
     ----------
     deployment_id : str
-    req : fastapi.Request
 
     Returns
     -------
     EventSourceResponse
     """
     controller = LogController()
-    stream = controller.event_logs(req, deployment_id)
+    stream = controller.event_logs(deployment_id=deployment_id)
     return EventSourceResponse(stream)

--- a/projects/api/experiments/experiments.py
+++ b/projects/api/experiments/experiments.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 """Experiments API Router."""
+from pathlib import PureWindowsPath
 from typing import Optional
-
-from fastapi import APIRouter, Depends, Header
+import urllib.parse
+from fastapi import APIRouter, Depends, Header, Request
+from sse_starlette.sse import EventSourceResponse
 from sqlalchemy.orm import Session
+import urllib.parse
 
 import projects.schemas.experiment
 from projects.controllers import ExperimentController, ProjectController
 from projects.database import session_scope
-
+from projects.kubernetes.argo import list_workflow_pods
+from projects.kfp.runs import get_latest_run_id
+from projects.kubernetes.utils import log_stream
 router = APIRouter(
     prefix="/projects/{project_id}/experiments",
 )
@@ -152,3 +157,40 @@ async def handle_delete_experiment(project_id: str,
     experiment = experiment_controller.delete_experiment(experiment_id=experiment_id,
                                                          project_id=project_id)
     return experiment
+
+
+@router.get("/{experiment_id}/{task_name}/logs/eventsource")
+async def handle_log_deployment(experiment_id: str,
+                                req: Request,
+                                task_name: str):
+    """
+    Handles log event source requests to /<experiment_id>/<task_name>/logs/eventsource.
+
+    Parameters
+    ----------
+    experiment_id : str
+    req : fastapi.Request
+    task_name: str
+
+    Returns
+    -------
+    EventSourceResponse
+    """
+    task_name = urllib.parse.unquote_plus(task_name)
+    run_id = get_latest_run_id(experiment_id)
+    pods = list_workflow_pods(run_id)
+    if len(pods) > 0:
+        for pod in pods:
+            if pod.metadata.annotations["name"] == task_name:
+                stream = log_stream(
+                    req, 
+                    pod.metadata.name, 
+                    pod.metadata.namespace,
+                    pod.spec.containers[0].name
+                    )
+                return EventSourceResponse(stream)
+        return "Could not find task with given name"
+    elif len(pods) == 0:
+        return "Unable to create log stream"
+    
+    

--- a/projects/api/experiments/experiments.py
+++ b/projects/api/experiments/experiments.py
@@ -179,7 +179,7 @@ async def handle_log_deployment(experiment_id: str,
     task_name = urllib.parse.unquote_plus(task_name)
     run_id = get_latest_run_id(experiment_id)
     pods = list_workflow_pods(run_id)
-    if len(pods) > 0:
+    if pods:
         for pod in pods:
             if pod.metadata.annotations["name"] == task_name:
                 stream = log_stream(
@@ -190,5 +190,5 @@ async def handle_log_deployment(experiment_id: str,
                 )
                 return EventSourceResponse(stream)
         return "Could not find task with given name"
-    elif len(pods) == 0:
+    else:
         return "Unable to create log stream"

--- a/projects/api/experiments/experiments.py
+++ b/projects/api/experiments/experiments.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Experiments API Router."""
-from pathlib import PureWindowsPath
+
 from typing import Optional
 import urllib.parse
+
 from fastapi import APIRouter, Depends, Header, Request
 from sse_starlette.sse import EventSourceResponse
 from sqlalchemy.orm import Session
-import urllib.parse
 
 import projects.schemas.experiment
 from projects.controllers import ExperimentController, ProjectController

--- a/projects/api/experiments/experiments.py
+++ b/projects/api/experiments/experiments.py
@@ -183,14 +183,12 @@ async def handle_log_deployment(experiment_id: str,
         for pod in pods:
             if pod.metadata.annotations["name"] == task_name:
                 stream = log_stream(
-                    req, 
-                    pod.metadata.name, 
+                    req,
+                    pod.metadata.name,
                     pod.metadata.namespace,
                     pod.spec.containers[0].name
-                    )
+                )
                 return EventSourceResponse(stream)
         return "Could not find task with given name"
     elif len(pods) == 0:
         return "Unable to create log stream"
-    
-    

--- a/projects/controllers/logs/logs.py
+++ b/projects/controllers/logs/logs.py
@@ -239,9 +239,7 @@ class LogController:
                 container=container_name,
                 pretty="true",
                 tail_lines=0,
-                timestamps=True,
-                # _request_timeout=30
-                # follow=True
+                timestamps=True
             ):
                 for message in self.split_messages(streamline, task_name, created_at):
                     yield(message.json())
@@ -288,7 +286,6 @@ class LogController:
             )
 
         iterators = list()
-        watchers = 0
 
         if not pods:
             raise BadRequest("Unable to create log stream. No active pod available.")
@@ -297,7 +294,6 @@ class LogController:
             for container in pod.spec.containers:
 
                 if container.name not in EXCLUDE_CONTAINERS:
-                    watchers += 1
                     iterators.append(self.log_stream(pod, container))
 
         return merge(iterators)

--- a/projects/controllers/logs/logs.py
+++ b/projects/controllers/logs/logs.py
@@ -10,6 +10,7 @@ from projects.kfp.runs import get_latest_run_id
 from projects.kubernetes.argo import list_workflow_pods
 from projects.kubernetes.seldon import list_deployment_pods
 from projects.kubernetes.utils import get_container_logs
+from projects.kubernetes.utils import log_stream
 from projects.schemas.log import Log, LogList
 
 EXCLUDE_CONTAINERS = ["istio-proxy", "wait"]
@@ -195,3 +196,37 @@ class LogController:
             )
 
         return logs
+
+    def event_logs(self, req,deployment_id):
+        pods = list()
+
+        # if deployment_id:
+        pods = list_deployment_pods(deployment_id)
+        # else:
+            # run_id = get_latest_run_id(experiment_id)
+            # pods = list_workflow_pods(run_id)
+        if len(pods) == 1:
+            pod_name = pods[0].metadata.name
+            print(pod_name)
+            namespace = pods[0].metadata.namespace
+            for container in pods[0].spec.containers:
+                if container.name not in EXCLUDE_CONTAINERS:
+                    container_name = container.name
+                    break
+            if container_name:
+                stream = log_stream(req, pod_name, namespace, container_name)
+            else:
+                stream = log_stream(req, pod_name, namespace)
+            return stream
+        # elif len(pods)>1:
+        #     for pod in pods:
+        #         if pod.metadata.annotations["name"] == task_name:
+        #             stream = log_stream(
+        #                 req,
+        #                 pod.metadata.name,
+        #                 pod.metadata.namespace,
+        #                 pod.spec.containers[0].name
+        #             )
+        #             return EventSourceResponse(stream)
+        else:
+            return

--- a/projects/controllers/operators/operators.py
+++ b/projects/controllers/operators/operators.py
@@ -409,34 +409,22 @@ class OperatorController:
                 yield "operator not running"
                 time.sleep(5)
             else:
-                try:
-                    resource_version = list_resource_version(
-                        group=GROUP,
-                        version=VERSION,
-                        namespace=KF_PIPELINES_NAMESPACE,
-                        plural=PLURAL,
-                    )
-                    w = Watch()
-                    stream = w.stream(
-                        api.list_namespaced_custom_object,
-                        group=GROUP,
-                        version=VERSION,
-                        namespace=KF_PIPELINES_NAMESPACE,
-                        plural=PLURAL,
-                        resource_version=resource_version,
-                        label_selector=f"pipeline/runid={run_id}",
-                        pretty="true",
-                    )
-                    for streamline in stream:
-                        yield f"Event: {streamline['type']} {streamline['object']['metadata']['name']}"
-                except RuntimeError as e:
-                    logging.exception(e)
-                    return
-
-                except asyncio.CancelledError as e:
-                    logging.exception(e)
-                    return
-
-                except ApiException as e:
-                    logging.exception(e)
-                    return
+                resource_version = list_resource_version(
+                    group=GROUP,
+                    version=VERSION,
+                    namespace=KF_PIPELINES_NAMESPACE,
+                    plural=PLURAL,
+                )
+                w = Watch()
+                stream = w.stream(
+                    api.list_namespaced_custom_object,
+                    group=GROUP,
+                    version=VERSION,
+                    namespace=KF_PIPELINES_NAMESPACE,
+                    plural=PLURAL,
+                    resource_version=resource_version,
+                    label_selector=f"pipeline/runid={run_id}",
+                    pretty="true",
+                )
+                for streamline in stream:
+                    yield f"Event: {streamline['type']} {streamline['object']['metadata']['name']}"

--- a/projects/kubernetes/utils.py
+++ b/projects/kubernetes/utils.py
@@ -225,7 +225,7 @@ async def log_stream(req, pod_name, namespace, container=None):
         pod_name: str
         namespace: str
         container: str
-    
+
     Yields
     ------
         str
@@ -283,10 +283,13 @@ async def log_stream(req, pod_name, namespace, container=None):
                     yield(streamline)
         except RuntimeError as e:
             logging.exception(e)
+            
         except asyncio.CancelledError as e:
             logging.exception(e)
+
         except ApiException as e:
             logging.exception(e)
+            
         except ReadTimeoutError:
             """
             Expected behavior if given container does not have any new log on log stream.

--- a/projects/kubernetes/utils.py
+++ b/projects/kubernetes/utils.py
@@ -158,7 +158,7 @@ def get_volume_from_pod(volume_name, namespace, experiment_id):
                     "mountPath": "/tmp/data",
                     "name": "vol-tmp-data"
                 }]
-              }],
+            }],
             "volumes": [{
                 "name": "vol-tmp-data",
                 "persistentVolumeClaim": {
@@ -237,15 +237,15 @@ async def log_stream(req, pod, namespace, container):
             break
         try:
             for streamline in w.stream(
-                    v1.read_namespaced_pod_log, 
-                    name=pod, 
-                    namespace=namespace,
-                    container=container,
-                    pretty="true",
-                    tail_lines=0,
-                    timestamps=True,
-                    _request_timeout=30
-                ):
+                v1.read_namespaced_pod_log,
+                name=pod,
+                namespace=namespace,
+                container=container,
+                pretty="true",
+                tail_lines=0,
+                timestamps=True,
+                _request_timeout=30
+            ):
                 yield(streamline)
         except RuntimeError as e:
             logging.exception(e)

--- a/projects/kubernetes/utils.py
+++ b/projects/kubernetes/utils.py
@@ -259,5 +259,3 @@ async def log_stream(req, pod, namespace, container):
             Timeout is needed because if there's no new log, the application blocks in the for loop and doesn't handle client disconnection.
             """
             pass
-        finally:
-            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ requests==2.25.1
 urllib3==1.26.5
 # FastAPI mailing library
 fastapi-mail==0.3.7
+# EventSource Api
+sse-starlette==0.6.2


### PR DESCRIPTION
Motivação: existem APIs que são utilizadas em formato polling (consulta periódica). Apesar de fácil de implementar, o polling não é a estratégia mais eficiente (trafega dados mesmo quando não há alterações na API).

Iremos criar uma API Eventsource (server side events) que é uma forma mais eficiente, que só trafega dados quando são gerados.

Foram criados os endpoints:

/projects/:id/experiments/:id/operators/eventsource