### PR TITLE
Including port 8000 in swagger

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10,6 +10,7 @@ info:
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 servers:
   - url: http://localhost:8080
+  - url: http://localhost:8000
 security:
   - ApiKeyAuth: []
 tags:


### PR DESCRIPTION
Uvicorn run as default on port 8000, so I thought that would be a good idea to include it in the swagger instead of just the 8080 port