### PR TITLE
Foi removido de forma temporaria o "kubeflow_userid: Optional[str] = …

### DIFF
--- a/projects/api/deployments/responses.py
+++ b/projects/api/deployments/responses.py
@@ -19,8 +19,7 @@ router = APIRouter(
 async def handle_post_responses(project_id: str,
                                 deployment_id: str,
                                 body: dict = Body(...),
-                                session: Session = Depends(session_scope),
-                                kubeflow_userid: Optional[str] = Header("anonymous")):
+                                session: Session = Depends(session_scope)):
     """
     Handles POST requests to /.
 
@@ -30,14 +29,11 @@ async def handle_post_responses(project_id: str,
     deployment_id : str
     body : fastapi.body
     session : sqlalchemy.orm.session.Session
-    kubeflow_userid : fastapi.Header
 
     Returns
     -------
     fastapi.responses.JSONResponse
     """
-    project_controller = ProjectController(session, kubeflow_userid=kubeflow_userid)
-    project_controller.raise_if_project_does_not_exist(project_id)
 
     deployment_controller = DeploymentController(session)
     deployment_controller.raise_if_deployment_does_not_exist(deployment_id)


### PR DESCRIPTION
Foi removido de forma temporaria o "kubeflow_userid: Optional[str] = Header(database.DB_TENANT)" dos parametros do handle_post_responses,
devido O monitoramento funciona com um logger do seldondeployment que envia um post para a API /projects/:id/deployments/:id/responses.
No entanto este post não possui o header kubeflow-userid, e a requisição retorna 404 para logins diferentes de anonymous.

Retirado tambem os controlles:
project_controller = ProjectController(session, kubeflow_userid=kubeflow_userid)
project_controller.raise_if_project_does_not_exist(project_id)