### PR TITLE
Fix/recursive import

### DIFF
--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 """Monitorings controller."""
+import warnings
+
+from sqlalchemy import event
+
 from projects import models, schemas
 from projects.controllers.deployments.runs.runs import RunController
 from projects.controllers.tasks import TaskController
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import NotFound
-from projects.kfp.monitorings import deploy_monitoring
-
+from projects.kfp.monitorings import deploy_monitoring, undeploy_monitoring
 
 NOT_FOUND = NotFound("The specified monitoring does not exist")
 
@@ -17,6 +20,22 @@ class MonitoringController:
         self.background_tasks = background_tasks
         self.run_controller = RunController(session)
         self.task_controller = TaskController(session)
+
+    @staticmethod
+    @event.listens_for(models.Monitoring, "after_delete")
+    def after_delete(_mapper, _connection, target):
+        """
+        Starts a pipeline that deletes K8s resources associated with target monitoring.
+        Parameters
+        ----------
+        _mapper : sqlalchemy.orm.Mapper
+        connection : sqlalchemy.engine.Connection
+        target : models.Monitoring
+        """
+        try:
+            undeploy_monitoring(monitoring_id=target.uuid)
+        except NotFound as e:
+            warnings.warn(e.message)
 
     def raise_if_monitoring_does_not_exist(self, monitoring_id: str):
         """
@@ -30,9 +49,12 @@ class MonitoringController:
         ------
         NotFound
         """
-        exists = self.session.query(models.Monitoring.uuid) \
-            .filter_by(uuid=monitoring_id) \
-            .scalar() is not None
+        exists = (
+            self.session.query(models.Monitoring.uuid)
+            .filter_by(uuid=monitoring_id)
+            .scalar()
+            is not None
+        )
 
         if not exists:
             raise NotFound("The specified monitoring does not exist")
@@ -49,14 +71,18 @@ class MonitoringController:
         -------
         projects.schemas.monitoring.MonitoringList
         """
-        monitorings = self.session.query(models.Monitoring) \
-            .filter_by(deployment_id=deployment_id) \
-            .order_by(models.Monitoring.created_at.asc()) \
+        monitorings = (
+            self.session.query(models.Monitoring)
+            .filter_by(deployment_id=deployment_id)
+            .order_by(models.Monitoring.created_at.asc())
             .all()
+        )
 
         return schemas.MonitoringList.from_orm(monitorings, len(monitorings))
 
-    def create_monitoring(self, monitoring: schemas.MonitoringCreate, deployment_id: str):
+    def create_monitoring(
+        self, monitoring: schemas.MonitoringCreate, deployment_id: str
+    ):
         """
         Creates a new monitoring in our database.
 
@@ -95,7 +121,7 @@ class MonitoringController:
             experiment_id=deployment.experiment_id,
             run_id=run["runId"],
             task_id=monitoring.task_id,
-            monitoring_id=monitoring.uuid
+            monitoring_id=monitoring.uuid,
         )
 
         return schemas.Monitoring.from_orm(monitoring)

--- a/projects/models/deployment.py
+++ b/projects/models/deployment.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 """Deployment model."""
 from datetime import datetime
-from warnings import warn
 
-from sqlalchemy import Boolean, Column, DateTime, event, \
-    Integer, String, Text, ForeignKey
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    String,
+    Text,
+    ForeignKey,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
-from projects.controllers.deployments.runs import RunController
 from projects.database import Base
 from projects.exceptions import NotFound
 from projects.models.monitoring import Monitoring
@@ -24,24 +29,20 @@ class Deployment(Base):
     experiment_id = Column(String(255), ForeignKey("experiments.uuid"), nullable=True)
     is_active = Column(Boolean, nullable=False, server_default=expression.true())
     name = Column(Text, nullable=False)
-    operators = relationship("Operator",
-                             primaryjoin=uuid == Operator.deployment_id,
-                             lazy="joined",
-                             cascade=CASCADE)
-    monitorings = relationship("Monitoring",
-                               primaryjoin=uuid == Monitoring.deployment_id,
-                               cascade=CASCADE)
+    operators = relationship(
+        "Operator",
+        primaryjoin=uuid == Operator.deployment_id,
+        lazy="joined",
+        cascade=CASCADE,
+    )
+    monitorings = relationship(
+        "Monitoring", primaryjoin=uuid == Monitoring.deployment_id, cascade=CASCADE
+    )
     position = Column(Integer, nullable=False, default=-1)
     status = Column(String(255), nullable=False, default="Pending")
     url = Column(String(255), nullable=True)
     deployed_at = Column(DateTime, nullable=True)
-    project_id = Column(String(255), ForeignKey("projects.uuid"), nullable=False, index=True)
+    project_id = Column(
+        String(255), ForeignKey("projects.uuid"), nullable=False, index=True
+    )
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-
-
-@event.listens_for(Deployment, "after_delete")
-def undeploy(_mapper, connection, target):
-    try:
-        RunController(connection).terminate_run(deployment_id=target.uuid)
-    except NotFound as e:
-        warn(e.message)

--- a/projects/models/monitoring.py
+++ b/projects/models/monitoring.py
@@ -1,29 +1,19 @@
 # -*- coding: utf-8 -*-
 """Monitoring model."""
 from datetime import datetime
-from warnings import warn
 
-from sqlalchemy import Column, DateTime, event, \
-    ForeignKey, String
+from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.orm import relationship
 
 from projects.database import Base
-from projects.exceptions import NotFound
-from projects.kfp import monitorings
 
 
 class Monitoring(Base):
     __tablename__ = "monitorings"
     uuid = Column(String(255), primary_key=True)
-    deployment_id = Column(String(255), ForeignKey("deployments.uuid"), nullable=True, index=True)
+    deployment_id = Column(
+        String(255), ForeignKey("deployments.uuid"), nullable=True, index=True
+    )
     task_id = Column(String(255), ForeignKey("tasks.uuid"), nullable=False, index=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     task = relationship("Task")
-
-
-@event.listens_for(Monitoring, "after_delete")
-def undeploy(_mapper, _connection, target):
-    try:
-        monitorings.undeploy_monitoring(monitoring_id=target.uuid)
-    except NotFound as e:
-        warn(e.message)


### PR DESCRIPTION
Moves models/deployment.py SQLAlchemy ORM event to DeploymentController 

models/deployment.py models used to import a RunController, but this
seems to be a bad pattern, since models should be only an 'Entity' and not
import/trigger much logic.
This also would cause recursive import problems if controller and kfp tried to import
models.

This update removes all controller imports from models/deployment.py, and moves those functions
to the Controller itself.

---

Moves models/monitoring.py SQLAlchemy ORM event to MonitoringController 

models/monitoring.py model used to import MonitoringController, but this
seems to be a bad pattern, since models should be only an 'Entity' and not
import/trigger much logic.
This also would cause recursive import problems if controller and kfp tried to import
models.

This update removes all controller imports from models/monitoring.py, and moves those functions
to the Controller itself.