### PR TITLE
Feature/error codes

### DIFF
--- a/CODE-REVIEW.md
+++ b/CODE-REVIEW.md
@@ -53,6 +53,29 @@ ex: `DELETE /resources/{resourceId}`
 ex: `PATCH /resources/{resourceId}`
 - Em dúvidas? Mantenha uma consistência com as URLs já existem.
 
+### Padrão para códigos e mensagens de erro
+- Use mensagens bastante descritivas. Pode usar várias frases sempre que necessário!
+- Para ids inexistentes **INFORMADOS NA URL**:
+```json
+{"code": "...NotFound", "message": "The specified ... does not exist.", "status": 404}
+```
+- Para ids inexistentes **INFORMADOS NO REQUEST BODY**:
+```json
+{"code": "Invalid...", "message": "source ... does not exist", "status": 400}
+```
+- Para campos obrigatórios faltantes (não validados pelo pydantic) **INFORMADOS NO REQUEST BODY**:
+```json
+{"code": "MissingRequired...", "message": "Necessary at least ...", "status": 400}
+```
+- Para campos que violam restruções de valor único **INFORMADOS NO REQUEST BODY**:
+```json
+{"code": "...Exists", "message": "a ... with that ... already exists", "status": 400}
+```
+- Para erros internos (ex: erro em operações do Kubernetes/Kubeflow):
+```json
+{"code": "Cannot...", "message": "...", "status": 500}
+```
+
 ## Testes Unitários
 - Todo teste deve ter um docstring descrevendo o que é testado:
 ```python

--- a/CODE-REVIEW.md
+++ b/CODE-REVIEW.md
@@ -57,23 +57,23 @@ ex: `PATCH /resources/{resourceId}`
 - Use mensagens bastante descritivas. Pode usar várias frases sempre que necessário!
 - Para ids inexistentes **INFORMADOS NA URL**:
 ```json
-{"code": "...NotFound", "message": "The specified ... does not exist.", "status_code": 404}
+{"code": "...NotFound", "message": "The specified ... does not exist."}
 ```
 - Para ids inexistentes **INFORMADOS NO REQUEST BODY**:
 ```json
-{"code": "Invalid...", "message": "source ... does not exist", "status_code": 400}
+{"code": "Invalid...", "message": "source ... does not exist"}
 ```
 - Para campos obrigatórios faltantes (não validados pelo pydantic) **INFORMADOS NO REQUEST BODY**:
 ```json
-{"code": "MissingRequired...", "message": "Necessary at least ...", "status_code": 400}
+{"code": "MissingRequired...", "message": "Necessary at least ..."}
 ```
 - Para campos que violam restruções de valor único **INFORMADOS NO REQUEST BODY**:
 ```json
-{"code": "...Exists", "message": "a ... with that ... already exists", "status_code": 400}
+{"code": "...Exists", "message": "a ... with that ... already exists"}
 ```
 - Para erros internos (ex: erro em operações do Kubernetes/Kubeflow):
 ```json
-{"code": "Cannot...", "message": "...", "status_code": 500}
+{"code": "Cannot...", "message": "..."}
 ```
 
 ## Testes Unitários

--- a/CODE-REVIEW.md
+++ b/CODE-REVIEW.md
@@ -57,23 +57,23 @@ ex: `PATCH /resources/{resourceId}`
 - Use mensagens bastante descritivas. Pode usar várias frases sempre que necessário!
 - Para ids inexistentes **INFORMADOS NA URL**:
 ```json
-{"code": "...NotFound", "message": "The specified ... does not exist.", "status": 404}
+{"code": "...NotFound", "message": "The specified ... does not exist.", "status_code": 404}
 ```
 - Para ids inexistentes **INFORMADOS NO REQUEST BODY**:
 ```json
-{"code": "Invalid...", "message": "source ... does not exist", "status": 400}
+{"code": "Invalid...", "message": "source ... does not exist", "status_code": 400}
 ```
 - Para campos obrigatórios faltantes (não validados pelo pydantic) **INFORMADOS NO REQUEST BODY**:
 ```json
-{"code": "MissingRequired...", "message": "Necessary at least ...", "status": 400}
+{"code": "MissingRequired...", "message": "Necessary at least ...", "status_code": 400}
 ```
 - Para campos que violam restruções de valor único **INFORMADOS NO REQUEST BODY**:
 ```json
-{"code": "...Exists", "message": "a ... with that ... already exists", "status": 400}
+{"code": "...Exists", "message": "a ... with that ... already exists", "status_code": 400}
 ```
 - Para erros internos (ex: erro em operações do Kubernetes/Kubeflow):
 ```json
-{"code": "Cannot...", "message": "...", "status": 500}
+{"code": "Cannot...", "message": "...", "status_code": 500}
 ```
 
 ## Testes Unitários

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3919,12 +3919,9 @@ components:
           type: string
         message:
           type: string
-        status_code:
-          type: integer
       required:
         - code
         - message
-        - status_code
     Forbidden:
       type: object
       properties:
@@ -3932,12 +3929,9 @@ components:
           type: string
         message:
           type: string
-        status_code:
-          type: integer
       required:
         - code
         - message
-        - status_code
     NotFound:
       type: object
       properties:
@@ -3945,12 +3939,9 @@ components:
           type: string
         message:
           type: string
-        status_code:
-          type: integer
       required:
         - code
         - message
-        - status_code
     InternalServerError:
       type: object
       properties:
@@ -3958,12 +3949,9 @@ components:
           type: string
         message:
           type: string
-        status_code:
-          type: integer
       required:
         - code
         - message
-        - status_code
     ServiceUnavailable:
       type: object
       properties:
@@ -3971,12 +3959,9 @@ components:
           type: string
         message:
           type: string
-        status_code:
-          type: integer
       required:
         - code
         - message
-        - status_code
   requestBodies:
     ComparisonPatch:
       content:
@@ -4597,13 +4582,9 @@ components:
                 type: string
               message:
                 type: string
-              status_code:
-                type: integer
-                example: 400
             required:
               - code
               - message
-              - status_code
     Forbidden:
       description: >
         Forbidden client error status response code indicates that the server
@@ -4617,13 +4598,9 @@ components:
                 type: string
               message:
                 type: string
-              status_code:
-                type: integer
-                example: 403
             required:
               - code
               - message
-              - status_code
     NotFound:
       description: >
         Not Found client error response code indicates that the server can't
@@ -4638,13 +4615,9 @@ components:
                 type: string
               message:
                 type: string
-              status_code:
-                type: integer
-                example: 404
             required:
               - code
               - message
-              - status_code
     InternalServerError:
       description: >
         Internal Server Error server error response code indicates that the
@@ -4660,13 +4633,9 @@ components:
                 type: string
               message:
                 type: string
-              status_code:
-                type: integer
-                example: 500
             required:
               - code
               - message
-              - status_code
     ServiceUnavailable:
       description: >
         Service Unavailable server error response code indicates that the server
@@ -4681,266 +4650,211 @@ components:
                 type: string
               message:
                 type: string
-              status_code:
-                type: integer
-                example: 503
             required:
               - code
               - message
-              - status_code
   examples:
     CannotConnectToDatabase:
       value:
         code: CannotConnectToDatabase
         message: Could not connect to database
-        status_code: 500
     MissingRequiredFormDataOrJson:
       value:
         code: MissingRequiredFormDataOrJson
         message: either form-data or json is required
-        status_code: 400
     InvalidDataset:
       value:
         code: InvalidDataset
         message: a valid dataset is required
-        status_code: 400
     MissingRequiredDatasetOrFile:
       value:
         code: MissingRequiredDatasetOrFile
         message: either dataset name or file is required
-        status_code: 400
     InvalidOrderBy:
       value:
         code: InvalidOrderBy
         message: Invalid order argument
-        status_code: 400
     ProjectNameExists:
       value:
         code: ProjectNameExists
         message: a project with that name already exists
-        status_code: 400
     MissingRequiredProjectId:
       value:
         code: MissingRequiredProjectId
         message: inform at least one project
-        status_code: 400
     MissingRequiredTemplateName:
       value:
         code: MissingRequiredTemplateName
         message: name is required
-        status_code: 400
     MissingRequiredExperimentIdOrDeploymentId:
       value:
         code: MissingRequiredExperimentIdOrDeploymentId
         message: experimentId or deploymentId needed to create template.
-        status_code: 400
     TemplateNameExists:
       value:
         code: TemplateNameExists
         message: a template with that name already exists
-        status_code: 400
     MissingRequiredTemplateId:
       value:
         code: MissingRequiredTemplateId
         message: inform at least one template
-        status_code: 400
     MissingRequiredExperimentsOrTemplateIdOrCopyFrom:
       value:
         code: MissingRequiredExperimentsOrTemplateIdOrCopyFrom
         message: 'either experiments, templateId or copyFrom is required'
-        status_code: 400
     MissingRequiredDeploymentName:
       value:
         code: MissingRequiredDeploymentName
         message: name is required to duplicate deployment
-        status_code: 400
     MissingRequiredOperatorId:
       value:
         code: MissingRequiredOperatorId
         message: Necessary at least one operator.
-        status_code: 400
     MissingRequiredDataSourceOperatorId:
       value:
         code: MissingRequiredDataSourceOperatorId
         message: Necessary at least one operator that is not a data source.
-        status_code: 400
     InvalidExperiments:
       value:
         code: InvalidExperiments
         message: some experiments do not exist
-        status_code: 400
     InvalidDeploymentId:
       value:
         code: InvalidDeploymentId
         message: source deployment does not exist
-        status_code: 400
     InvalidRunId:
       value:
         code: InvalidRunId
         message: Not a failed run
-        status_code: 400
     MissingRequiredExperimentName:
       value:
         code: MissingRequiredExperimentName
         message: name is required
-        status_code: 400
     DeploymentNameExists:
       value:
         code: DeploymentNameExists
         message: a deployment with that name already exists
-        status_code: 400
     ExperimentNameExists:
       value:
         code: ExperimentNameExists
         message: an experiment with that name already exists
-        status_code: 400
     InvalidExperimentId:
       value:
         code: InvalidExperimentId
         message: source experiment does not exist
-        status_code: 400
     InvalidTemplateId:
       value:
         code: InvalidTemplateId
         message: The specified template does not exist
-        status_code: 400
     CannotCreateLogStream:
       value:
         code: CannotCreateLogStream
         message: Unable to create log stream. No active pod available.
-        status_code: 500
     CannotCreateNamespacedPod:
       value:
         code: CannotCreateNamespacedPod
         message: 'Error while trying to create pod: {message}'
-        status_code: 500
     MissingRequiredTaskId:
       value:
         code: MissingRequiredTaskId
         message: taskId is required
-        status_code: 400
     InvalidOperatorRequestBody:
       value:
         code: InvalidOperatorRequestBody
         message: Operator cannot contain an experiment and a deployment simultaneously
-        status_code: 400
     InvalidParameters:
       value:
         code: InvalidParameters
         message: The specified parameters are not valid
-        status_code: 400
     InvalidDependencies:
       value:
         code: InvalidDependencies
         message: The specified dependencies are not valid.
-        status_code: 400
     InvalidCyclicalDependencies:
       value:
         code: InvalidCyclicalDependencies
         message: Cyclical dependencies.
-        status_code: 400
     MissingRequiredNotebookOrTaskId:
       value:
         code: MissingRequiredNotebookOrTaskId
         message: Either provide notebooks or a task to copy from
-        status_code: 400
     TaskNameExists:
       value:
         code: TaskNameExists
         message: a task with that name already exists
-        status_code: 400
     InvalidTaskId:
       value:
         code: InvalidTaskId
         message: source task does not exist
-        status_code: 400
     InvalidCategory:
       value:
         code: InvalidCategory
         message: 'Invalid category. Choose any of {valid_categories}'
-        status_code: 400
     InvalidDockerImageName:
       value:
         code: InvalidDockerImageName
         message: invalid docker image name
-        status_code: 400
     TaskProtectedFromDeletion:
       value:
         code: TaskProtectedFromDeletion
         message: Task related to an operator
-        status_code: 403
     CannotConnectToCluster:
       value:
         code: CannotConnectToCluster
         message: Failed to connect to cluster.
-        status_code: 500
     CannotCreatePersistentVolumeClaim:
       value:
         code: CannotCreatePersistentVolumeClaim
         message: 'Error while trying to create persistent volume claim: {message}'
-        status_code: 500
     CannotPatchNotebookServer:
       value:
         code: CannotPatchNotebookServer
         message: 'Error while trying to patch notebook server: {message}'
-        status_code: 500
     CannotRetrieveContainerLogs:
       value:
         code: CannotRetrieveContainerLogs
         message: 'Error while trying to retrieve container''s log: {message}'
-        status_code: 500
     ComparisonNotFound:
       value:
         code: ComparisonNotFound
         message: The specified comparison does not exist.
-        status_code: 404
     DeploymentNotFound:
       value:
         code: DeploymentNotFound
         message: The specified deployment does not exist.
-        status_code: 404
     ExperimentNotFound:
       value:
         code: ExperimentNotFound
         message: The specified experiment does not exist.
-        status_code: 404
     MonitoringNotFound:
       value:
         code: MonitoringNotFound
         message: The specified monitoring does not exist.
-        status_code: 404
     OperatorNotFound:
       value:
         code: OperatorNotFound
         message: The specified operator does not exist.
-        status_code: 404
     PredictionNotFound:
       value:
         code: PredictionNotFound
         message: The specified prediction does not exist.
-        status_code: 404
     ProjectNotFound:
       value:
         code: ProjectNotFound
         message: The specified project does not exist.
-        status_code: 404
     RunNotFound:
       value:
         code: RunNotFound
         message: The specified run does not exist.
-        status_code: 404
     TaskNotFound:
       value:
         code: TaskNotFound
         message: The specified task does not exist.
-        status_code: 404
     TemplateNotFound:
       value:
         code: TemplateNotFound
         message: The specified template does not exist.
-        status_code: 404
     DatasetNotFound:
       value:
         code: DatasetNotFound
         message: The specified run does not contain dataset.
-        status_code: 404

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3852,6 +3852,23 @@ components:
                 type: integer
                 example: 500
 
+    CannotCreateNamespacedPod:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "CannotCreateNamespacedPod"
+              message:
+                type: string
+                example: "Error while trying to create pod: {message}"
+              status:
+                type: integer
+                example: 500
+
     MissingRequiredTaskId:
       description: ""
       content:
@@ -4102,7 +4119,7 @@ components:
                 example: "CannotRetrieveContainerLogs"
               message:
                 type: string
-                example: "Error while trying to retrive container's log: {message}"
+                example: "Error while trying to retrieve container's log: {message}"
               status:
                 type: integer
                 example: 500

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2584,6 +2584,7 @@ components:
         deploymentId:
           type: string
           format: uuid
+
   requestBodies:
     ComparisonPatch:
       content:
@@ -3269,3 +3270,839 @@ components:
                 example: "The service is unavailable. Try your call again."
             required:
               - message
+
+    ################################################################################
+    # ERROR RESPONSES
+    ################################################################################
+    ComparisonNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "ComparisonNotFound"
+              message:
+                type: string
+                example: "The specified comparision does not exist."
+              status:
+                type: integer
+                example: 404
+
+    DeploymentNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "DeploymentNotFound"
+              message:
+                type: string
+                example: "The specified deployment does not exist."
+              status:
+                type: integer
+                example: 404
+
+    ExperimentNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "ExperimentNotFound"
+              message:
+                type: string
+                example: "The specified experiment does not exist."
+              status:
+                type: integer
+                example: 404
+
+    MonitoringNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MonitoringNotFound"
+              message:
+                type: string
+                example: "The specified monitoring does not exist."
+              status:
+                type: integer
+                example: 404
+
+    OperatorNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "OperatorNotFound"
+              message:
+                type: string
+                example: "The specified operator does not exist."
+              status:
+                type: integer
+                example: 404
+
+    PredictionNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "PredictionNotFound"
+              message:
+                type: string
+                example: "The specified prediction does not exist."
+              status:
+                type: integer
+                example: 404
+
+    ProjectNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "ProjectNotFound"
+              message:
+                type: string
+                example: "The specified project does not exist."
+              status:
+                type: integer
+                example: 404
+
+    RunNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "RunNotFound"
+              message:
+                type: string
+                example: "The specified run does not exist."
+              status:
+                type: integer
+                example: 404
+
+    TaskNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "TaskNotFound"
+              message:
+                type: string
+                example: "The specified task does not exist."
+              status:
+                type: integer
+                example: 404
+
+    TemplateNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "TemplateNotFound"
+              message:
+                type: string
+                example: "The specified template does not exist."
+              status:
+                type: integer
+                example: 404
+
+    InternalError:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InternalError"
+              message:
+                type: string
+                example: "The server encountered an internal error. Please retry the request."
+              status:
+                type: integer
+                example: 500
+
+    CannotConnectToDatabase:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "CannotConnectToDatabase"
+              message:
+                type: string
+                example: "Could not connect to database"
+              status:
+                type: integer
+                example: 500
+
+    MissingRequiredFormDataOrJson:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredFormDataOrJson"
+              message:
+                type: string
+                example: "either form-data or json is required"
+              status:
+                type: integer
+                example: 400
+
+    InvalidDataset:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidDataset"
+              message:
+                type: string
+                example: "a valid dataset is required"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredDatasetOrFile:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredDatasetOrFile"
+              message:
+                type: string
+                example: "either dataset name or file is required"
+              status:
+                type: integer
+                example: 400
+
+    InvalidOrderBy:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidOrderBy"
+              message:
+                type: string
+                example: "Invalid order argument"
+              status:
+                type: integer
+                example: 400
+
+    ProjectNameExists:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "ProjectNameExists"
+              message:
+                type: string
+                example: "a project with that name already exists"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredProjectId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredProjectId"
+              message:
+                type: string
+                example: "inform at least one project"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredTemplateName:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredTemplateName"
+              message:
+                type: string
+                example: "name is required"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredExperimentIdOrDeploymentId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredExperimentIdOrDeploymentId"
+              message:
+                type: string
+                example: "experimentId or deploymentId needed to create template."
+              status:
+                type: integer
+                example: 400
+
+    TemplateNameExists:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "TemplateNameExists"
+              message:
+                type: string
+                example: "a template with that name already exists"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredTemplateId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredTemplateId"
+              message:
+                type: string
+                example: "inform at least one template"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredExperimentsOrTemplateIdOrCopyFrom:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredExperimentsOrTemplateIdOrCopyFrom"
+              message:
+                type: string
+                example: "either experiments, templateId or copyFrom is required"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredDeploymentName:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredDeploymentName"
+              message:
+                type: string
+                example: "name is required to duplicate deployment"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredOperatorId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredOperatorId"
+              message:
+                type: string
+                example: "Necessary at least one operator."
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredDataSourceOperatorId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredDataSourceOperatorId"
+              message:
+                type: string
+                example: "Necessary at least one operator that is not a data source."
+              status:
+                type: integer
+                example: 400
+
+    InvalidExperiments:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidExperiments"
+              message:
+                type: string
+                example: "some experiments do not exist"
+              status:
+                type: integer
+                example: 400
+
+    InvalidDeploymentId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidDeploymentId"
+              message:
+                type: string
+                example: "source deployment does not exist"
+              status:
+                type: integer
+                example: 400
+
+    InvalidRunId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidRunId"
+              message:
+                type: string
+                example: "Not a failed run"
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredExperimentName:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredExperimentName"
+              message:
+                type: string
+                example: "name is required"
+              status:
+                type: integer
+                example: 400
+
+    ExperimentNameExists:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "ExperimentNameExists"
+              message:
+                type: string
+                example: "an experiment with that name already exists"
+              status:
+                type: integer
+                example: 400
+
+    InvalidExperimentId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidExperimentId"
+              message:
+                type: string
+                example: "source experiment does not exist"
+              status:
+                type: integer
+                example: 400
+
+    InvalidTemplateId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidTemplateId"
+              message:
+                type: string
+                example: "The specified template does not exist"
+              status:
+                type: integer
+                example: 400
+
+    CannotCreateLogStream:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "CannotConnectToLogStream"
+              message:
+                type: string
+                example: "Unable to create log stream. No active pod available."
+              status:
+                type: integer
+                example: 500
+
+    MissingRequiredTaskId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredTaskId"
+              message:
+                type: string
+                example: "taskId is required"
+              status:
+                type: integer
+                example: 400
+
+    InvalidOperatorRequestBody:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidOperatorRequestBody"
+              message:
+                type: string
+                example: "Operator cannot contain an experiment and a deployment simultaneously"
+              status:
+                type: integer
+                example: 400
+
+    InvalidParameters:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidParameters"
+              message:
+                type: string
+                example: "The specified parameters are not valid"
+              status:
+                type: integer
+                example: 400
+
+    InvalidDependencies:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidDependencies"
+              message:
+                type: string
+                example: "The specified dependencies are not valid."
+              status:
+                type: integer
+                example: 400
+
+    InvalidCyclicalDependencies:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidCyclicalDependencies"
+              message:
+                type: string
+                example: "Cyclical dependencies."
+              status:
+                type: integer
+                example: 400
+
+    MissingRequiredNotebookOrTaskId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "MissingRequiredNotebookOrTaskId"
+              message:
+                type: string
+                example: "Either provide notebooks or a task to copy from"
+              status:
+                type: integer
+                example: 400
+
+    TaskNameExists:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: ""
+              message:
+                type: string
+                example: "a task with that name already exists"
+              status:
+                type: integer
+                example: 400
+
+    InvalidTaskId:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidTaskId"
+              message:
+                type: string
+                example: "source task does not exist"
+              status:
+                type: integer
+                example: 400
+
+    InvalidCategory:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidCategory"
+              message:
+                type: string
+                example: "Invalid category. Choose any of {valid_categories}"
+              status:
+                type: integer
+                example: 400
+
+    InvalidDockerImageName:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "InvalidDockerImageName"
+              message:
+                type: string
+                example: "invalid docker image name"
+              status:
+                type: integer
+                example: 400
+
+    TaskProtectedFromDeletion:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "TaskProtectedFromDeletion"
+              message:
+                type: string
+                example: "Task related to an operator"
+              status:
+                type: integer
+                example: 403
+
+    CannotConnectToCluster:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "CannotConnectToCluster"
+              message:
+                type: string
+                example: "Failed to connect to cluster."
+              status:
+                type: integer
+                example: 400
+
+    CannotCreatePersistentVolumeClaim:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "CannotCreatePersistentVolumeClaim"
+              message:
+                type: string
+                example: "Error while trying to create persistent volume claim: {message}"
+              status:
+                type: integer
+                example: 400
+
+    CannotPatchNotebookServer:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "CannotPatchNotebookServer"
+              message:
+                type: string
+                example: "Error while trying to patch notebook server: {message}"
+              status:
+                type: integer
+                example: 400
+
+    CannotRetrieveContainerLogs:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "CannotRetrieveContainerLogs"
+              message:
+                type: string
+                example: "Error while trying to retrive container's log: {message}"
+              status:
+                type: integer
+                example: 500

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3286,7 +3286,7 @@ components:
                 example: "ComparisonNotFound"
               message:
                 type: string
-                example: "The specified comparision does not exist."
+                example: "The specified comparison does not exist."
               status:
                 type: integer
                 example: 404

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,84 +1,105 @@
 openapi: 3.0.0
 info:
   title: PlatIAgro Projects API
-  version: "0.3.0"
+  version: 0.3.0
   description: >
-    These are the docs for PlatIAgro Projects API.
-    The endpoints below are usually accessed by the PlatIAgro Web-UI.
+    These are the docs for PlatIAgro Projects API. The endpoints below are
+    usually accessed by the PlatIAgro Web-UI.
   license:
-    name: "Apache 2.0"
-    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 servers:
-  - url: http://localhost:8080
-  - url: http://localhost:8000
+  - url: 'http://localhost:8080'
+  - url: 'http://localhost:8000'
 security:
   - ApiKeyAuth: []
 tags:
-  - name: "Tasks"
+  - name: Healthcheck
+    description: |
+      Healthcheck indicates the current status of the API server.
+  - name: Tasks
     description: >
-      Tasks are tools and algorithms that a data-scientist writes in Jupyter Notebooks or in a Docker image.
-      You may use these tasks as a step of an experiment to perform model training or inference.
-  - name: "Projects"
+      Tasks are tools and algorithms that a data-scientist writes in Jupyter
+      Notebooks or in a Docker image. You may use these tasks as a step of an
+      experiment to perform model training or inference.
+  - name: Projects
     description: >
-      Projects are a way to organize the problems a data-scientist is trying to solve.
-      In a project, you may test different experiments (hypothesis/solutions/models) that address the business question you are trying to answer.
-  - name: "Experiments"
+      Projects are a way to organize the problems a data-scientist is trying to
+      solve. In a project, you may test different experiments
+      (hypothesis/solutions/models) that address the business question you are
+      trying to answer.
+  - name: Experiments
     description: >
       Experiments allow data-scientists to draw acyclic workflows using tasks.
       These workflows may describe the steps of data-preparation, data-modeling.
-  - name: "Experiment Operators"
+  - name: Experiment Operators
     description: >
-      An Operator is a single unit in an experiment flow.
-      When a data-scientist runs an experiment, the operator runs a Jupyter Notebook of its task.
-  - name: "Experiment Runs"
+      An Operator is a single unit in an experiment flow. When a data-scientist
+      runs an experiment, the operator runs a Jupyter Notebook of its task.
+  - name: Experiment Runs
     description: >
-      Runs are the executions of an experiment.
-      Each run start from the first step and generates its own results.
-  - name: "Deployments"
+      Runs are the executions of an experiment. Each run start from the first
+      step and generates its own results.
+  - name: Deployments
     description: >
       Deployments allow drawing sequential workflows for real-time inference.
       These workflows are accessible by HTTP via REST endpoints.
-  - name: "Deployment Operators"
+  - name: Deployment Operators
     description: >
-      An Operator is a single unit in a deployment flow.
-      When someone tests a deployment, the operator is a service that runs the Model.py of its task.
-  - name: "Deployment Runs"
+      An Operator is a single unit in a deployment flow. When someone tests a
+      deployment, the operator is a service that runs the Model.py of its task.
+  - name: Deployment Runs
     description: >
-      Runs are the executions of a deployment.
-      Each run start from the first step and generates its own results.
-  - name: "Predictions"
-    description: >
+      Runs are the executions of a deployment. Each run start from the first
+      step and generates its own results.
+  - name: Predictions
+    description: |
       Predictions send a request with file data to seldon deployment.
-  - name: "Results"
+  - name: Results
     description: >
-      Results are the outputs of experiment runs.
-      They are: figures, metrics, datasets and log messages.
-  - name: "Logs"
-    description: >
+      Results are the outputs of experiment runs. They are: figures, metrics,
+      datasets and log messages.
+  - name: Logs
+    description: |
       Output logs of runs.
-  - name: "Comparisons"
+  - name: Comparisons
     description: >
-      Comparisons organize results from different experiments for evaluation/comparision.
-  - name: "Templates"
+      Comparisons organize results from different experiments for
+      evaluation/comparision.
+  - name: Templates
     description: >
-      Templates are reusable workflows that a data-scientist may use to draw an experiment quickly.
-  - name: "Monitorings"
+      Templates are reusable workflows that a data-scientist may use to draw an
+      experiment quickly.
+  - name: Monitorings
     description: >
-      Monitorings allow to ensure that models are maintaining a predetermined desired level of performance.
+      Monitorings allow to ensure that models are maintaining a predetermined
+      desired level of performance.
 paths:
   /healthcheck:
     get:
-      summary: "Check the connection with the database."
+      summary: Check the connection with the database.
+      tags:
+        - Healthcheck
       responses:
-        "200":
-          description: "Successfully connected to database"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          description: Successfully connected to database
+        '503':
+          description: >
+            Service Unavailable server error response code indicates that the
+            server is not ready to handle the request. A common cause is that
+            the database is not available or overloaded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailable'
+              examples:
+                CannotConnectToDatabase:
+                  $ref: '#/components/examples/CannotConnectToDatabase'
   /tasks:
     get:
-      summary: "List tasks. Supports pagination, and sorting."
+      summary: 'List tasks. Supports pagination, and sorting.'
       tags:
-        - "Tasks"
+        - Tasks
       parameters:
         - in: query
           name: name
@@ -101,32 +122,62 @@ paths:
             type: string
           example: uuid asc
       responses:
-        "200":
-          $ref: "#/components/responses/Tasks"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Tasks'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                InvalidOrderBy:
+                  $ref: '#/components/examples/InvalidOrderBy'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new task."
+      summary: Create a new task.
       tags:
-        - "Tasks"
+        - Tasks
       requestBody:
-        $ref: "#/components/requestBodies/TaskPost"
+        $ref: '#/components/requestBodies/TaskPost'
       responses:
-        "200":
-          $ref: "#/components/responses/Task"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Task'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                MissingRequiredNotebookOrTaskId:
+                  $ref: '#/components/examples/MissingRequiredNotebookOrTaskId'
+                TaskNameExists:
+                  $ref: '#/components/examples/TaskNameExists'
+                InvalidTaskId:
+                  $ref: '#/components/examples/InvalidTaskId'
+                InvalidCategory:
+                  $ref: '#/components/examples/InvalidCategory'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /tasks/{taskId}:
     get:
-      summary: "Detail a specific task by ID."
+      summary: Detail a specific task by ID.
       tags:
-        - "Tasks"
+        - Tasks
       parameters:
         - name: taskId
           in: path
@@ -135,18 +186,28 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Task"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Task'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TaskNotFound:
+                  $ref: '#/components/examples/TaskNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     patch:
-      summary: "Update a task by ID."
+      summary: Update a task by ID.
       tags:
-        - "Tasks"
+        - Tasks
       parameters:
         - name: taskId
           in: path
@@ -155,22 +216,45 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/TaskPatch"
+        $ref: '#/components/requestBodies/TaskPatch'
       responses:
-        "200":
-          $ref: "#/components/responses/Task"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Task'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                TaskNameExists:
+                  $ref: '#/components/examples/TaskNameExists'
+                InvalidCategory:
+                  $ref: '#/components/examples/InvalidCategory'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TaskNotFound:
+                  $ref: '#/components/examples/TaskNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Delete a task by ID."
+      summary: Delete a task by ID.
       tags:
-        - "Tasks"
+        - Tasks
       parameters:
         - name: taskId
           in: path
@@ -178,19 +262,40 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '403':
+          description: >
+            Forbidden client error status response code indicates that the
+            server understands the request but refuses to authorize it.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Forbidden'
+              examples:
+                TaskProtectedFromDeletion:
+                  $ref: '#/components/examples/TaskProtectedFromDeletion'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TaskNotFound:
+                  $ref: '#/components/examples/TaskNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /tasks/{taskId}/parameters:
     get:
-      summary: "List all parameters."
+      summary: List all parameters.
       tags:
-        - "Tasks"
+        - Tasks
       parameters:
         - name: taskId
           in: path
@@ -199,42 +304,62 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Parameters"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Parameters'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TaskNotFound:
+                  $ref: '#/components/examples/TaskNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /tasks/{taskId}/emails:
     post:
-      summary: "Send email with task folder content"
+      summary: Send email with task folder content
       tags:
-        - "Tasks"
+        - Tasks
       requestBody:
-        $ref: "#/components/requestBodies/TaskMailing"
+        $ref: '#/components/requestBodies/TaskMailing'
       parameters:
-      - name: taskId
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+        - name: taskId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/TaskMailing"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/TaskMailing'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TaskNotFound:
+                  $ref: '#/components/examples/TaskNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects:
     get:
-      summary: "List projects. Supports pagination, and sorting."
+      summary: 'List projects. Supports pagination, and sorting.'
       tags:
-        - "Projects"
+        - Projects
       parameters:
         - in: query
           name: name
@@ -257,32 +382,56 @@ paths:
             type: string
           example: name asc
       responses:
-        "200":
-          $ref: "#/components/responses/Projects"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Projects'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                InvalidOrderBy:
+                  $ref: '#/components/examples/InvalidOrderBy'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new project."
+      summary: Create a new project.
       tags:
-        - "Projects"
+        - Projects
       requestBody:
-        $ref: "#/components/requestBodies/Project"
+        $ref: '#/components/requestBodies/Project'
       responses:
-        "200":
-          $ref: "#/components/responses/Project"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Project'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                ProjectNameExists:
+                  $ref: '#/components/examples/ProjectNameExists'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}:
     get:
-      summary: "Detail a specific project by ID."
+      summary: Detail a specific project by ID.
       tags:
-        - "Projects"
+        - Projects
       parameters:
         - name: projectId
           in: path
@@ -291,18 +440,28 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Project"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Project'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     patch:
-      summary: "Update a project by ID."
+      summary: Update a project by ID.
       tags:
-        - "Projects"
+        - Projects
       parameters:
         - name: projectId
           in: path
@@ -311,22 +470,43 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/Project"
+        $ref: '#/components/requestBodies/Project'
       responses:
-        "200":
-          $ref: "#/components/responses/Project"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Project'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                ProjectNameExists:
+                  $ref: '#/components/examples/ProjectNameExists'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Delete a project by ID."
+      summary: Delete a project by ID.
       tags:
-        - "Projects"
+        - Projects
       parameters:
         - name: projectId
           in: path
@@ -335,35 +515,56 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/deleteprojects:
     post:
-      summary: "Delete multiple projects."
+      summary: Delete multiple projects.
       tags:
-        - "Projects"
+        - Projects
       requestBody:
-        $ref: "#/components/requestBodies/Deleteprojects"
+        $ref: '#/components/requestBodies/Deleteprojects'
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                MissingRequiredProjectId:
+                  $ref: '#/components/examples/MissingRequiredProjectId'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/comparisons:
     get:
-      summary: "List all comparisons sorted by created_at in ascending order."
+      summary: List all comparisons sorted by created_at in ascending order.
       tags:
-        - "Comparisons"
+        - Comparisons
       parameters:
         - name: projectId
           in: path
@@ -372,18 +573,28 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Comparisons"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Comparisons'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new comparison."
+      summary: Create a new comparison.
       tags:
-        - "Comparisons"
+        - Comparisons
       parameters:
         - name: projectId
           in: path
@@ -392,21 +603,29 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Comparison"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Comparison'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/comparisons/{comparisonId}:
     patch:
-      summary: "Update a comparison by ID."
+      summary: Update a comparison by ID.
       tags:
-        - "Comparisons"
+        - Comparisons
       parameters:
         - name: projectId
           in: path
@@ -421,22 +640,45 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/ComparisonPatch"
+        $ref: '#/components/requestBodies/ComparisonPatch'
       responses:
-        "200":
-          $ref: "#/components/responses/Comparison"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Comparison'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                InvalidExperimentId:
+                  $ref: '#/components/examples/InvalidExperimentId'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ComparisonNotFound:
+                  $ref: '#/components/examples/ComparisonNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Delete a comparison by ID."
+      summary: Delete a comparison by ID.
       tags:
-        - "Comparisons"
+        - Comparisons
       parameters:
         - name: projectId
           in: path
@@ -451,19 +693,31 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ComparisonNotFound:
+                  $ref: '#/components/examples/ComparisonNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments:
     get:
-      summary: "List all experiments sorted by position in ascending order."
+      summary: List all experiments sorted by position in ascending order.
       tags:
-        - "Experiments"
+        - Experiments
       parameters:
         - name: projectId
           in: path
@@ -472,18 +726,28 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Experiments"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Experiments'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new experiment."
+      summary: Create a new experiment.
       tags:
-        - "Experiments"
+        - Experiments
       parameters:
         - name: projectId
           in: path
@@ -492,23 +756,44 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/ExperimentPost"
+        $ref: '#/components/requestBodies/ExperimentPost'
       responses:
-        "200":
-          $ref: "#/components/responses/Experiment"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Experiment'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                ExperimentNameExists:
+                  $ref: '#/components/examples/ExperimentNameExists'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}:
     get:
-      summary: "Detail a specific experiment by ID."
+      summary: Detail a specific experiment by ID.
       tags:
-        - "Experiments"
+        - Experiments
       parameters:
         - name: projectId
           in: path
@@ -523,18 +808,30 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Experiment"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Experiment'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     patch:
-      summary: "Update an experiment by ID."
+      summary: Update an experiment by ID.
       tags:
-        - "Experiments"
+        - Experiments
       parameters:
         - name: projectId
           in: path
@@ -549,22 +846,47 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/ExperimentPatch"
+        $ref: '#/components/requestBodies/ExperimentPatch'
       responses:
-        "200":
-          $ref: "#/components/responses/Experiment"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Experiment'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                ExperimentNameExists:
+                  $ref: '#/components/examples/ExperimentNameExists'
+                InvalidTemplateId:
+                  $ref: '#/components/examples/InvalidTemplateId'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Delete an experiment by ID."
+      summary: Delete an experiment by ID.
       tags:
-        - "Experiments"
+        - Experiments
       parameters:
         - name: projectId
           in: path
@@ -579,46 +901,81 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/logs/eventsource:
     get:
-        summary: "Server sent events of log stream of pods used in the given experiment."
-        tags:
-          - "Experiments"
-        parameters:
-          - name: projectId
-            in: path
-            required: true
-            schema:
-              type: string
-              format: uuid
-          - name: experimentId
-            in: path
-            required: true
-            schema:
-              type: string
-              format: uuid
-        responses:
-          "200":
-            description: "Returns log stream"
-          "400":
-            $ref: "#/components/responses/BadRequest"
-          "500":
-            $ref: "#/components/responses/InternalServerError"
-          "503":
-            $ref: "#/components/responses/ServiceUnavailable"
+      summary: Server sent events of log stream of pods used in the given experiment.
+      tags:
+        - Logs
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Returns log stream
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotCreateLogStream:
+                  $ref: '#/components/examples/CannotCreateLogStream'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/operators:
     get:
-      summary: "List all operators, unsorted."
+      summary: 'List all operators, unsorted.'
       tags:
-        - "Experiment Operators"
+        - Experiment Operators
       parameters:
         - name: projectId
           in: path
@@ -633,18 +990,30 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Operators"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Operators'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new operator."
+      summary: Create a new operator.
       tags:
-        - "Experiment Operators"
+        - Experiment Operators
       parameters:
         - name: projectId
           in: path
@@ -659,23 +1028,54 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/OperatorPost"
+        $ref: '#/components/requestBodies/OperatorPost'
       responses:
-        "200":
-          $ref: "#/components/responses/Operator"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Operator'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                MissingRequiredTaskId:
+                  $ref: '#/components/examples/MissingRequiredTaskId'
+                InvalidTaskId:
+                  $ref: '#/components/examples/InvalidTaskId'
+                InvalidOperatorRequestBody:
+                  $ref: '#/components/examples/InvalidOperatorRequestBody'
+                InvalidParameters:
+                  $ref: '#/components/examples/InvalidParameters'
+                InvalidDependencies:
+                  $ref: '#/components/examples/InvalidDependencies'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/operators/eventsource:
     get:
-      summary: "Server sent events of operator's status change stream."
+      summary: Server sent events of operator's status change stream.
       tags:
-        - "Experiment Operators"
+        - Experiment Operators
       parameters:
         - name: projectId
           in: path
@@ -690,13 +1090,42 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          description: "Returns log stream"
+        '200':
+          description: Returns log stream
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotCreateLogStream:
+                  $ref: '#/components/examples/CannotCreateLogStream'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/operators/{operatorId}:
     patch:
-      summary: "Update an operator by ID."
+      summary: Update an operator by ID.
       tags:
-        - "Experiment Operators"
+        - Experiment Operators
       parameters:
         - name: projectId
           in: path
@@ -717,22 +1146,51 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/OperatorPatch"
+        $ref: '#/components/requestBodies/OperatorPatch'
       responses:
-        "200":
-          $ref: "#/components/responses/Operator"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Operator'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                InvalidTaskId:
+                  $ref: '#/components/examples/InvalidTaskId'
+                InvalidParameters:
+                  $ref: '#/components/examples/InvalidParameters'
+                InvalidDependencies:
+                  $ref: '#/components/examples/InvalidDependencies'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Delete an operator by ID."
+      summary: Delete an operator by ID.
       tags:
-        - "Experiment Operators"
+        - Experiment Operators
       parameters:
         - name: projectId
           in: path
@@ -753,19 +1211,33 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/operators/{operatorId}/parameters/{name}:
     patch:
-      summary: "Update a parameter value."
+      summary: Update a parameter value.
       tags:
-        - "Experiment Operators"
+        - Experiment Operators
       parameters:
         - in: path
           name: projectId
@@ -785,27 +1257,41 @@ paths:
           schema:
             type: string
         - name: name
-          description: "Parameter name."
+          description: Parameter name.
           in: path
           required: true
           schema:
             type: string
       requestBody:
-        $ref: "#/components/requestBodies/ParameterPatch"
+        $ref: '#/components/requestBodies/ParameterPatch'
       responses:
-        "200":
-          $ref: "#/components/responses/AnyValue"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
+        '200':
+          $ref: '#/components/responses/AnyValue'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/runs:
     get:
-      summary: "List all experiment runs sorted by created_at in ascending order."
+      summary: List all experiment runs sorted by created_at in ascending order.
       tags:
-        - "Experiment Runs"
+        - Experiment Runs
       parameters:
         - in: path
           name: projectId
@@ -820,18 +1306,41 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Run"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Run'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new experiment run."
+      summary: Create a new experiment run.
       tags:
-        - "Experiment Runs"
+        - Experiment Runs
       parameters:
         - in: path
           name: projectId
@@ -846,21 +1355,44 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/RunPost"
+        $ref: '#/components/requestBodies/RunPost'
       responses:
-        "200":
-          $ref: "#/components/responses/Run"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Run'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/runs/{runId}:
     get:
-      summary: "Detail a specific experiment run by ID."
+      summary: Detail a specific experiment run by ID.
       tags:
-        - "Experiment Runs"
+        - Experiment Runs
       parameters:
         - in: path
           name: projectId
@@ -880,18 +1412,43 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/Run"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Run'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Terminate an experiment run."
+      summary: Terminate an experiment run.
       tags:
-        - "Experiment Runs"
+        - Experiment Runs
       parameters:
         - in: path
           name: projectId
@@ -911,19 +1468,44 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/runs/{runId}/retry:
     put:
-      summary: "Re-initiate a failed or terminated experiment run."
+      summary: Re-initiate a failed or terminated experiment run.
       tags:
-        - "Experiment Runs"
+        - Experiment Runs
       parameters:
         - in: path
           name: projectId
@@ -943,19 +1525,44 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/runs/{runId}/results:
     get:
-      summary: "Download a zip file with all results from run."
+      summary: Download a zip file with all results from run.
       tags:
-        - "Results"
+        - Results
       parameters:
         - in: path
           name: projectId
@@ -975,19 +1582,103 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/RunResults"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/RunResults'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/experiments/{experimentId}/runs/{runId}/data:
+    get:
+      summary: Download a zip file with all data saved in a run.
+      tags:
+        - Results
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/RunResults'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotCreateNamespacedPod:
+                  $ref: '#/components/examples/CannotCreateNamespacedPod'
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/runs/{runId}/operators/{operatorId}/results:
     get:
-      summary: "Download a zip file with all results from operator."
+      summary: Download a zip file with all results from operator.
       tags:
-        - "Results"
+        - Results
       parameters:
         - in: path
           name: projectId
@@ -1013,19 +1704,46 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/RunResults"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/RunResults'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/experiments/{experimentId}/runs/{runId}/operators/{operatorId}/datasets:
     get:
-      summary: "List datasets. Supports pagination."
+      summary: List datasets. Supports pagination.
       tags:
-        - "Results"
+        - Results
       parameters:
         - in: path
           name: projectId
@@ -1061,364 +1779,616 @@ paths:
             type: integer
           description: Page size
       responses:
-        "200":
-          $ref: "#/components/responses/Datasets"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/experiments/{experimentId}/runs/{runId}/operators/{operatorId}/figures:
-    get:
-      summary: "List all figures"
-      tags:
-        - "Results"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: experimentId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: runId
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: operatorId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          $ref: "#/components/responses/Figures"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/experiments/{experimentId}/runs/{runId}/operators/{operatorId}/metrics:
-    get:
-      summary: "List all metrics"
-      tags:
-        - "Results"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: experimentId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: runId
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: operatorId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          $ref: "#/components/responses/Metrics"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/experiments/{experimentId}/runs/{runId}/logs:
-    get:
-      summary: "Get logs from an experiment run"
-      tags:
-        - "Logs"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: experimentId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: runId
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          $ref: "#/components/responses/Logs"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/deployments:
-    get:
-      summary: "List all deployments."
-      tags:
-        - "Deployments"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          $ref: "#/components/responses/Deployments"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-    post:
-      summary: "Create a new deployment."
-      tags:
-        - "Deployments"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        $ref: "#/components/requestBodies/DeploymentPost"
-      responses:
-        "200":
-          $ref: "#/components/responses/Deployments"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/deployments/{deploymentId}:
-    get:
-      summary: "Detail a specific deployment by ID."
-      tags:
-        - "Deployments"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - in: path
-          name: deploymentId
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          $ref: "#/components/responses/Deployment"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-    patch:
-      summary: "Update a deployment by ID."
-      tags:
-        - "Deployments"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - in: path
-          name: deploymentId
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        $ref: "#/components/requestBodies/DeploymentPatch"
-      responses:
-        "200":
-          $ref: "#/components/responses/Deployment"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-    delete:
-      summary: "Delete a deployment by ID."
-      tags:
-        - "Deployments"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: deploymentId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/deployments/{deploymentId}/logs/eventsource:
-   get:
-       summary: "Server sent events of log stream of pods used in the given deployment."
-       tags:
-         - "Deployments"
-       parameters:
-         - in: path
-           name: projectId
-           required: true
-           schema:
-             type: string
-             format: uuid
-         - in: path
-           name: deploymentId
-           required: true
-           schema:
-             type: string
-             format: uuid
-       responses:
-         "200":
-           description: "Returns log stream"
-         "400":
-           $ref: "#/components/responses/BadRequest"
-         "500":
-           $ref: "#/components/responses/InternalServerError"
-         "503":
-           $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/deployments/{deploymentId}/operators:
-    get:
-      summary: "List all operators, unsorted."
-      tags:
-        - "Deployment Operators"
-      parameters:
-        - name: projectId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: deploymentId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          $ref: "#/components/responses/Operators"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/deployments/{deploymentId}/operators/{operatorId}:
-    patch:
-      summary: "Update an operator by ID."
-      tags:
-        - "Deployment Operators"
-      parameters:
-        - name: projectId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: deploymentId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - name: operatorId
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      requestBody:
-        $ref: "#/components/requestBodies/OperatorPatch"
-      responses:
-        "200":
-          $ref: "#/components/responses/Operator"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-  /projects/{projectId}/deployments/{deploymentId}/monitorings:
-    get:
-      summary: "Lists all monitorings."
-      tags:
-        - "Monitorings"
-      parameters:
-        - in: path
-          name: projectId
-          required: true
-          schema:
-            type: string
-            format: uuid
-        - in: path
-          name: deploymentId
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        "200":
-          description: ""
+        '200':
+          $ref: '#/components/responses/Datasets'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Monitorings"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
-    post:
-      summary: "Create a monitoring."
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+                DatasetNotFound:
+                  $ref: '#/components/examples/DatasetNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/experiments/{experimentId}/runs/{runId}/operators/{operatorId}/figures:
+    get:
+      summary: List all figures
       tags:
-        - "Monitorings"
+        - Results
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: operatorId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/Figures'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/experiments/{experimentId}/runs/{runId}/operators/{operatorId}/metrics:
+    get:
+      summary: List all metrics
+      tags:
+        - Results
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: operatorId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/Metrics'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/experiments/{experimentId}/runs/{runId}/logs:
+    get:
+      summary: Get logs from an experiment run
+      tags:
+        - Logs
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/Logs'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                ExperimentNotFound:
+                  $ref: '#/components/examples/ExperimentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+                CannotRetrieveContainerLogs:
+                  $ref: '#/components/examples/CannotRetrieveContainerLogs'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/deployments:
+    get:
+      summary: List all deployments.
+      tags:
+        - Deployments
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/Deployments'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    post:
+      summary: Create a new deployment.
+      tags:
+        - Deployments
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        $ref: '#/components/requestBodies/DeploymentPost'
+      responses:
+        '200':
+          $ref: '#/components/responses/Deployments'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                MissingRequiredExperimentsOrTemplateIdOrCopyFrom:
+                  $ref: >-
+                    #/components/examples/MissingRequiredExperimentsOrTemplateIdOrCopyFrom
+                MissingRequiredDeploymentName:
+                  $ref: '#/components/examples/MissingRequiredDeploymentName'
+                DeploymentNameExists:
+                  $ref: '#/components/examples/DeploymentNameExists'
+                MissingRequiredOperatorId:
+                  $ref: '#/components/examples/MissingRequiredOperatorId'
+                MissingRequiredDataSourceOperatorId:
+                  $ref: '#/components/examples/MissingRequiredDataSourceOperatorId'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/deployments/{deploymentId}:
+    get:
+      summary: Detail a specific deployment by ID.
+      tags:
+        - Deployments
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/Deployment'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    patch:
+      summary: Update a deployment by ID.
+      tags:
+        - Deployments
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        $ref: '#/components/requestBodies/DeploymentPatch'
+      responses:
+        '200':
+          $ref: '#/components/responses/Deployment'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                DeploymentNameExists:
+                  $ref: '#/components/examples/DeploymentNameExists'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    delete:
+      summary: Delete a deployment by ID.
+      tags:
+        - Deployments
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/deployments/{deploymentId}/logs/eventsource:
+    get:
+      summary: Server sent events of log stream of pods used in the given deployment.
+      tags:
+        - Logs
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Returns log stream
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/deployments/{deploymentId}/operators:
+    get:
+      summary: 'List all operators, unsorted.'
+      tags:
+        - Deployment Operators
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/Operators'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/deployments/{deploymentId}/operators/{operatorId}:
+    patch:
+      summary: Update an operator by ID.
+      tags:
+        - Deployment Operators
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: deploymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: operatorId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        $ref: '#/components/requestBodies/OperatorPatch'
+      responses:
+        '200':
+          $ref: '#/components/responses/Operator'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                InvalidTaskId:
+                  $ref: '#/components/examples/InvalidTaskId'
+                InvalidParameters:
+                  $ref: '#/components/examples/InvalidParameters'
+                InvalidDependencies:
+                  $ref: '#/components/examples/InvalidDependencies'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+                OperatorNotFound:
+                  $ref: '#/components/examples/OperatorNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+  /projects/{projectId}/deployments/{deploymentId}/monitorings:
+    get:
+      summary: Lists all monitorings.
+      tags:
+        - Monitorings
+      parameters:
+        - in: path
+          name: projectId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitorings'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    post:
+      summary: Create a monitoring.
+      tags:
+        - Monitorings
       parameters:
         - in: path
           name: projectId
@@ -1441,23 +2411,48 @@ paths:
                 taskId:
                   type: string
       responses:
-        "200":
-          description: ""
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Monitoring"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+                $ref: '#/components/schemas/Monitoring'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                InvalidTaskId:
+                  $ref: '#/components/examples/InvalidTaskId'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/deployments/{deploymentId}/monitorings/{monitoringId}:
     delete:
-      summary: "Delete a monitoring by ID."
+      summary: Delete a monitoring by ID.
       tags:
-        - "Monitorings"
+        - Monitorings
       parameters:
         - in: path
           name: projectId
@@ -1478,17 +2473,33 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+                MonitoringNotFound:
+                  $ref: '#/components/examples/MonitoringNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/deployments/{deploymentId}/monitorings/{monitoringId}/figures:
     get:
-      summary: "List all figures"
+      summary: List all figures
       tags:
-        - "Monitorings"
+        - Monitorings
       parameters:
         - in: path
           name: projectId
@@ -1509,17 +2520,33 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Figures"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Figures'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+                MonitoringNotFound:
+                  $ref: '#/components/examples/MonitoringNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/deployments/{deploymentId}/runs:
     get:
-      summary: "List all experiment runs sorted by created_at in ascending order."
+      summary: List all experiment runs sorted by created_at in ascending order.
       tags:
-        - "Deployment Runs"
+        - Deployment Runs
       parameters:
         - in: path
           name: projectId
@@ -1534,18 +2561,41 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Run"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Run'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new deployment run."
+      summary: Create a new deployment run.
       tags:
-        - "Deployment Runs"
+        - Deployment Runs
       parameters:
         - in: path
           name: projectId
@@ -1560,21 +2610,44 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/RunPost"
+        $ref: '#/components/requestBodies/RunPost'
       responses:
-        "200":
-          $ref: "#/components/responses/Run"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Run'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/deployments/{deploymentId}/runs/{runId}:
     get:
-      summary: "Detail a specific deployment run by ID."
+      summary: Detail a specific deployment run by ID.
       tags:
-        - "Deployment Runs"
+        - Deployment Runs
       parameters:
         - in: path
           name: projectId
@@ -1594,18 +2667,43 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/Run"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Run'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Terminate a deployment run."
+      summary: Terminate a deployment run.
       tags:
-        - "Deployment Runs"
+        - Deployment Runs
       parameters:
         - in: path
           name: projectId
@@ -1625,21 +2723,46 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/deployments/{deploymentId}/predictions:
     post:
-      summary: "Create a new prediction sending a file."
+      summary: Create a new prediction sending a file.
       tags:
-        - "Predictions"
+        - Predictions
       requestBody:
-        $ref: "#/components/requestBodies/PredictionPost"
+        $ref: '#/components/requestBodies/PredictionPost'
       parameters:
         - in: path
           name: projectId
@@ -1654,19 +2777,57 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Prediction"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
+        '200':
+          $ref: '#/components/responses/Prediction'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                InvalidDataset:
+                  $ref: '#/components/examples/InvalidDataset'
+                MissingRequiredDatasetOrFile:
+                  $ref: '#/components/examples/MissingRequiredDatasetOrFile'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/deployments/{deploymentId}/predictions/{predictionId}:
     get:
-      summary: "Gets prediciton object and returns as json"
+      summary: Gets prediciton object and returns as json
       tags:
-        - "Predictions"
+        - Predictions
       parameters:
         - in: path
           name: projectId
@@ -1685,19 +2846,33 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid    
+            format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/PredictionInfo"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"        
+        '200':
+          $ref: '#/components/responses/PredictionInfo'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+                PredictionNotFound:
+                  $ref: '#/components/examples/PredictionNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /projects/{projectId}/deployments/{deploymentId}/runs/{runId}/logs:
     get:
-      summary: "Get logs from a deployment run"
+      summary: Get logs from a deployment run
       tags:
-        - "Logs"
+        - Logs
       parameters:
         - in: path
           name: projectId
@@ -1716,17 +2891,46 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: "#/components/responses/Logs"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Logs'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+                RunNotFound:
+                  $ref: '#/components/examples/RunNotFound'
+        '500':
+          description: >
+            Internal Server Error server error response code indicates that the
+            server encountered an unexpected condition that prevented it from
+            fulfilling the request. This error response is a generic "catch-all"
+            response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                CannotConnectToCluster:
+                  $ref: '#/components/examples/CannotConnectToCluster'
+                CannotRetrieveContainerLogs:
+                  $ref: '#/components/examples/CannotRetrieveContainerLogs'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /projects/{projectId}/deployments/{deploymentId}/responses:
     post:
-      summary: "Create a deployment response."
+      summary: Create a deployment response.
       tags:
-        - "Deployments"
+        - Deployments
       parameters:
         - in: path
           name: projectId
@@ -1741,46 +2945,80 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/ResponsePost"
+        $ref: '#/components/requestBodies/ResponsePost'
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                ProjectNotFound:
+                  $ref: '#/components/examples/ProjectNotFound'
+                DeploymentNotFound:
+                  $ref: '#/components/examples/DeploymentNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /templates:
     get:
-      summary: "List all templates sorted by name in natural sort order."
+      summary: List all templates sorted by name in natural sort order.
       tags:
-        - "Templates"
+        - Templates
       responses:
-        "200":
-          $ref: "#/components/responses/Templates"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Templates'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     post:
-      summary: "Create a new template from an experiment."
+      summary: Create a new template from an experiment.
       tags:
-        - "Templates"
+        - Templates
       requestBody:
-        $ref: "#/components/requestBodies/TemplatePost"
+        $ref: '#/components/requestBodies/TemplatePost'
       responses:
-        "200":
-          $ref: "#/components/responses/Template"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Template'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                MissingRequiredTemplateName:
+                  $ref: '#/components/examples/MissingRequiredTemplateName'
+                MissingRequiredExperimentIdOrDeploymentId:
+                  $ref: >-
+                    #/components/examples/MissingRequiredExperimentIdOrDeploymentId
+                InvalidExperimentId:
+                  $ref: '#/components/examples/InvalidExperimentId'
+                InvalidDeploymentId:
+                  $ref: '#/components/examples/InvalidDeploymentId'
+                TemplateNameExists:
+                  $ref: '#/components/examples/TemplateNameExists'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /templates/{templateId}:
     get:
-      summary: "Detail a specific template by ID."
+      summary: Detail a specific template by ID.
       tags:
-        - "Templates"
+        - Templates
       parameters:
         - name: templateId
           in: path
@@ -1789,18 +3027,28 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Template"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Template'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TemplateNotFound:
+                  $ref: '#/components/examples/TemplateNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     patch:
-      summary: "Update a template by ID."
+      summary: Update a template by ID.
       tags:
-        - "Templates"
+        - Templates
       parameters:
         - name: templateId
           in: path
@@ -1809,22 +3057,43 @@ paths:
             type: string
             format: uuid
       requestBody:
-        $ref: "#/components/requestBodies/TemplatePatch"
+        $ref: '#/components/requestBodies/TemplatePatch'
       responses:
-        "200":
-          $ref: "#/components/responses/Template"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Template'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                TemplateNameExists:
+                  $ref: '#/components/examples/TemplateNameExists'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TemplateNotFound:
+                  $ref: '#/components/examples/TemplateNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
-      summary: "Delete a template by ID."
+      summary: Delete a template by ID.
       tags:
-        - "Templates"
+        - Templates
       parameters:
         - name: templateId
           in: path
@@ -1833,30 +3102,51 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '404':
+          description: >
+            Not Found client error response code indicates that the server can't
+            find the requested resource. A common cause is that a provided ID
+            does not exist in the database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+              examples:
+                TemplateNotFound:
+                  $ref: '#/components/examples/TemplateNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /templates/deletetemplates:
     post:
-      summary: "Delete multiple templates."
+      summary: Delete multiple templates.
       tags:
-        - "Templates"
+        - Templates
       requestBody:
-        $ref: "#/components/requestBodies/Deletetemplates"
+        $ref: '#/components/requestBodies/Deletetemplates'
       responses:
-        "200":
-          $ref: "#/components/responses/Message"
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+        '200':
+          $ref: '#/components/responses/Message'
+        '400':
+          description: >
+            Bad Request response status code indicates that the server cannot or
+            will not process the request due to something that is perceived to
+            be a client error. A common cause is that the client has sent
+            invalid request values.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+              examples:
+                MissingRequiredTemplateId:
+                  $ref: '#/components/examples/MissingRequiredTemplateId'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -1866,7 +3156,9 @@ components:
   schemas:
     AnyValue:
       nullable: true
-      description: Can be any value - string, number, boolean, array or object, including `null`.
+      description: >-
+        Can be any value - string, number, boolean, array or object, including
+        `null`.
     Comparison:
       type: object
       properties:
@@ -1907,7 +3199,7 @@ components:
     Comparisons:
       type: array
       items:
-        $ref: "#/components/schemas/Comparison"
+        $ref: '#/components/schemas/Comparison'
     Task:
       type: object
       properties:
@@ -1920,8 +3212,15 @@ components:
           type: string
         category:
           type: string
-          enum: ["DATASETS", "DEFAULT", "DESCRIPTIVE_STATISTICS", "FEATURE_ENGINEERING",
-                 "PREDICTOR", "COMPUTER_VISION", "NLP", "MONITORING"]
+          enum:
+            - DATASETS
+            - DEFAULT
+            - DESCRIPTIVE_STATISTICS
+            - FEATURE_ENGINEERING
+            - PREDICTOR
+            - COMPUTER_VISION
+            - NLP
+            - MONITORING
         tags:
           type: array
           items:
@@ -1957,7 +3256,7 @@ components:
         parameters:
           type: array
           items:
-            $ref: "#/components/schemas/Parameter"
+            $ref: '#/components/schemas/Parameter'
         createdAt:
           type: string
           format: date-time
@@ -1970,7 +3269,7 @@ components:
         tasks:
           type: array
           items:
-            $ref: "#/components/schemas/Task"
+            $ref: '#/components/schemas/Task'
         total:
           type: integer
     TaskEmpty:
@@ -2055,7 +3354,9 @@ components:
       properties:
         type:
           type: string
-          enum: [string, integer]
+          enum:
+            - string
+            - integer
         name:
           type: string
         default:
@@ -2063,7 +3364,7 @@ components:
     Parameters:
       type: array
       items:
-        $ref: "#/components/schemas/Parameter"
+        $ref: '#/components/schemas/Parameter'
     Project:
       type: object
       properties:
@@ -2077,11 +3378,11 @@ components:
         experiments:
           type: array
           items:
-            $ref: "#/components/schemas/Experiment"
+            $ref: '#/components/schemas/Experiment'
         deployments:
           type: array
           items:
-            $ref: "#/components/schemas/Deployment"
+            $ref: '#/components/schemas/Deployment'
         createdAt:
           type: string
           format: date-time
@@ -2100,7 +3401,7 @@ components:
         projects:
           type: array
           items:
-            $ref: "#/components/schemas/Project"
+            $ref: '#/components/schemas/Project'
         total:
           type: integer
     Experiment:
@@ -2119,7 +3420,7 @@ components:
           type: string
           format: uuid
         operators:
-          $ref: "#/components/schemas/Operators"
+          $ref: '#/components/schemas/Operators'
         createdAt:
           type: string
           format: date-time
@@ -2129,7 +3430,7 @@ components:
     Experiments:
       type: array
       items:
-        $ref: "#/components/schemas/Experiment"
+        $ref: '#/components/schemas/Experiment'
     Deployment:
       type: object
       properties:
@@ -2146,7 +3447,7 @@ components:
         operators:
           type: array
           items:
-            $ref: "#/components/schemas/Operator"
+            $ref: '#/components/schemas/Operator'
         position:
           type: integer
         status:
@@ -2165,7 +3466,7 @@ components:
         deployments:
           type: array
           items:
-            $ref: "#/components/schemas/Deployment"
+            $ref: '#/components/schemas/Deployment'
         total:
           type: integer
     Prediction:
@@ -2178,8 +3479,12 @@ components:
           type: string
           format: uuid
         status:
-          type: string    
-          enum: [not_started, started, done, failed]
+          type: string
+          enum:
+            - not_started
+            - started
+            - done
+            - failed
     PredictionInfo:
       type: object
       properties:
@@ -2200,8 +3505,12 @@ components:
           type: string
           format: date
         status:
-          type: string    
-          enum: [not_started, started, done, failed]      
+          type: string
+          enum:
+            - not_started
+            - started
+            - done
+            - failed
     Data:
       type: object
       properties:
@@ -2239,7 +3548,7 @@ components:
           additionalProperties:
             description: 'Can be anything: string, number, array, object, etc.'
           example:
-            content-type: "image/jpg"
+            content-type: image/jpg
     SeldonDefaultData:
       type: object
       additionalProperties: false
@@ -2281,7 +3590,12 @@ components:
               pattern: '^.{1,2097152}'
               maxLength: 2097152
               format: int64
-              description: 'Size of the tensor in that dimension. This value must be >= -1, but values of -1 are reserved for "unknown" shapes (values of -1 mean "unknown" dimension).  Certain wrappers that work with TensorShapeProto may fail at runtime when deserializing a TensorShapeProto containing a dim value of -1.'
+              description: >-
+                Size of the tensor in that dimension. This value must be >= -1,
+                but values of -1 are reserved for "unknown" shapes (values of -1
+                mean "unknown" dimension).  Certain wrappers that work with
+                TensorShapeProto may fail at runtime when deserializing a
+                TensorShapeProto containing a dim value of -1.
             name:
               type: string
               pattern: '^.{1,2097152}'
@@ -2346,7 +3660,7 @@ components:
     Monitorings:
       type: array
       items:
-        $ref: "#/components/schemas/Monitoring"
+        $ref: '#/components/schemas/Monitoring'
     DeploymentTemplate:
       type: object
       properties:
@@ -2384,7 +3698,7 @@ components:
             parameters:
               type: array
               items:
-                $ref: "#/components/schemas/Parameter"
+                $ref: '#/components/schemas/Parameter'
         dependencies:
           type: array
           items:
@@ -2414,14 +3728,21 @@ components:
           format: date-time
         status:
           type: string
-          enum: [Unset, Setted up, Pending, Running, Failed, Succeeded, Terminated]
+          enum:
+            - Unset
+            - Setted up
+            - Pending
+            - Running
+            - Failed
+            - Succeeded
+            - Terminated
           example: Setted up
         statusMessage:
           type: string
     Operators:
       type: array
       items:
-        $ref: "#/components/schemas/Operator"
+        $ref: '#/components/schemas/Operator'
     Logs:
       type: object
       properties:
@@ -2435,14 +3756,20 @@ components:
             properties:
               level:
                 type: string
-                enum: [DEBUG, INFO, WARNING, ERROR]
+                enum:
+                  - DEBUG
+                  - INFO
+                  - WARNING
+                  - ERROR
                 example: INFO
               title:
                 type: string
                 example: Regressor Random Forest
               message:
                 type: string
-                example: seldon_core.microservice:load_annotations:114 Found annotation deployment_version
+                example: >-
+                  seldon_core.microservice:load_annotations:114 Found annotation
+                  deployment_version
               createdAt:
                 type: string
                 format: date-time
@@ -2456,9 +3783,9 @@ components:
             items:
               oneOf:
                 - type: string
-                  example: "SepalLengthCm"
+                  example: SepalLengthCm
                 - type: string
-                  example: "Species"
+                  example: Species
           data:
             type: array
             items:
@@ -2469,7 +3796,7 @@ components:
                       - type: number
                         example: 5.1
                       - type: string
-                        example: "Iris-setosa"
+                        example: Iris-setosa
           total:
             type: number
             example: 2
@@ -2477,7 +3804,8 @@ components:
       type: array
       items:
         type: string
-        example: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAAC6CAIAAAB3B9X3AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAG6SURBVHhe7dIxAQAADMOg+TfdicgLGrhBIBCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhDB9ho69eEGiUHfAAAAAElFTkSuQmCC"
+        example: >-
+          data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAAC6CAIAAAB3B9X3AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAG6SURBVHhe7dIxAQAADMOg+TfdicgLGrhBIBCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhCJQCQCkQhEIhDB9ho69eEGiUHfAAAAAElFTkSuQmCC
     Metrics:
       type: array
       items:
@@ -2516,12 +3844,12 @@ components:
               parameters:
                 type: object
                 example:
-                  dataset: "/tmp/data/iris.csv"
-                  target: "SepalLengthCm"
+                  dataset: /tmp/data/iris.csv
+                  target: SepalLengthCm
     Runs:
       type: array
       items:
-        $ref: "#/components/schemas/Run"
+        $ref: '#/components/schemas/Run'
     Template:
       type: object
       properties:
@@ -2567,7 +3895,7 @@ components:
     Templates:
       type: array
       items:
-        $ref: "#/components/schemas/Template"
+        $ref: '#/components/schemas/Template'
     TemplateExperiment:
       type: object
       properties:
@@ -2584,7 +3912,71 @@ components:
         deploymentId:
           type: string
           format: uuid
-
+    BadRequest:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        status_code:
+          type: integer
+      required:
+        - code
+        - message
+        - status_code
+    Forbidden:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        status_code:
+          type: integer
+      required:
+        - code
+        - message
+        - status_code
+    NotFound:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        status_code:
+          type: integer
+      required:
+        - code
+        - message
+        - status_code
+    InternalServerError:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        status_code:
+          type: integer
+      required:
+        - code
+        - message
+        - status_code
+    ServiceUnavailable:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        status_code:
+          type: integer
+      required:
+        - code
+        - message
+        - status_code
   requestBodies:
     ComparisonPatch:
       content:
@@ -2606,7 +3998,7 @@ components:
                 properties:
                   x:
                     type: number
-                  y:
+                  'y':
                     type: number
                   w:
                     type: number
@@ -2617,25 +4009,26 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: "#/components/schemas/TaskEmpty"
-              - $ref: "#/components/schemas/TaskDocker"
-              - $ref: "#/components/schemas/TaskCopyFrom"
-              - $ref: "#/components/schemas/TaskNotebooks"
+              - $ref: '#/components/schemas/TaskEmpty'
+              - $ref: '#/components/schemas/TaskDocker'
+              - $ref: '#/components/schemas/TaskCopyFrom'
+              - $ref: '#/components/schemas/TaskNotebooks'
           examples:
             empty:
               summary: Empty notebooks
               value:
                 name: string
                 description: string
-                category: "DEFAULT"
-                tags: ["DEFAULT"]
+                category: DEFAULT
+                tags:
+                  - DEFAULT
                 dataIn: string
                 dataOut: string
                 docs: string
-                cpuLimit: "1000m"
-                cpuRequest: "1000m"
-                memoryLimit: "10G"
-                memoryRequest: "10G"
+                cpuLimit: 1000m
+                cpuRequest: 1000m
+                memoryLimit: 10G
+                memoryRequest: 10G
             unnamed_notebook:
               summary: Unnamed notebook
               value: {}
@@ -2644,24 +4037,28 @@ components:
               value:
                 name: string
                 description: string
-                category: "DEFAULT"
-                tags: ["DEFAULT"]
+                category: DEFAULT
+                tags:
+                  - DEFAULT
                 dataIn: string
                 dataOut: string
                 docs: string
-                commands: ["cmd"]
-                arguments: ["arg"]
-                image: your-custom-docker-image:tag
-                cpuLimit: "1000m"
-                cpuRequest: "1000m"
-                memoryLimit: "10G"
-                memoryRequest: "10G"
+                commands:
+                  - cmd
+                arguments:
+                  - arg
+                image: 'your-custom-docker-image:tag'
+                cpuLimit: 1000m
+                cpuRequest: 1000m
+                memoryLimit: 10G
+                memoryRequest: 10G
             copyFrom:
               summary: Copy another task
               value:
                 name: string
                 description: string
-                tags: ["DEFAULT"]
+                tags:
+                  - DEFAULT
                 copyFrom: 3fa85f64-5717-4562-b3fc-2c963f66afa6
             notebook:
               summary: Upload notebooks in request body
@@ -2669,182 +4066,144 @@ components:
                 name: string
                 description: string
                 category: DEFAULT
-                tags: ["DEFAULT"]
+                tags:
+                  - DEFAULT
                 dataIn: string
                 dataOut: string
                 docs: string
-                cpuLimit: "1000m"
-                cpuRequest: "1000m"
-                memoryLimit: "10G"
-                memoryRequest: "10G"
+                cpuLimit: 1000m
+                cpuRequest: 1000m
+                memoryLimit: 10G
+                memoryRequest: 10G
                 deploymentNotebook:
-                  {
-                    "cells":
-                      [
-                        {
-                          "cell_type": "code",
-                          "execution_count": null,
-                          "metadata": {},
-                          "outputs": [],
-                          "source": [],
-                        },
-                      ],
-                    "metadata":
-                      {
-                        "kernelspec":
-                          {
-                            "display_name": "Python 3",
-                            "language": "python",
-                            "name": "python3",
-                          },
-                        "language_info":
-                          {
-                            "codemirror_mode":
-                              { "name": "ipython", "version": 3 },
-                            "file_extension": ".py",
-                            "mimetype": "text/x-python",
-                            "name": "python",
-                            "nbconvert_exporter": "python",
-                            "pygments_lexer": "ipython3",
-                            "version": "3.6.9",
-                          },
-                      },
-                    "nbformat": 4,
-                    "nbformat_minor": 4,
-                  }
+                  cells:
+                    - cell_type: code
+                      execution_count: null
+                      metadata: {}
+                      outputs: []
+                      source: []
+                  metadata:
+                    kernelspec:
+                      display_name: Python 3
+                      language: python
+                      name: python3
+                    language_info:
+                      codemirror_mode:
+                        name: ipython
+                        version: 3
+                      file_extension: .py
+                      mimetype: text/x-python
+                      name: python
+                      nbconvert_exporter: python
+                      pygments_lexer: ipython3
+                      version: 3.6.9
+                  nbformat: 4
+                  nbformat_minor: 4
                 experimentNotebook:
-                  {
-                    "cells":
-                      [
-                        {
-                          "cell_type": "code",
-                          "execution_count": null,
-                          "metadata": {},
-                          "outputs": [],
-                          "source": [],
-                        },
-                      ],
-                    "metadata":
-                      {
-                        "kernelspec":
-                          {
-                            "display_name": "Python 3",
-                            "language": "python",
-                            "name": "python3",
-                          },
-                        "language_info":
-                          {
-                            "codemirror_mode":
-                              { "name": "ipython", "version": 3 },
-                            "file_extension": ".py",
-                            "mimetype": "text/x-python",
-                            "name": "python",
-                            "nbconvert_exporter": "python",
-                            "pygments_lexer": "ipython3",
-                            "version": "3.6.9",
-                          },
-                      },
-                    "nbformat": 4,
-                    "nbformat_minor": 4,
-                  }
+                  cells:
+                    - cell_type: code
+                      execution_count: null
+                      metadata: {}
+                      outputs: []
+                      source: []
+                  metadata:
+                    kernelspec:
+                      display_name: Python 3
+                      language: python
+                      name: python3
+                    language_info:
+                      codemirror_mode:
+                        name: ipython
+                        version: 3
+                      file_extension: .py
+                      mimetype: text/x-python
+                      name: python
+                      nbconvert_exporter: python
+                      pygments_lexer: ipython3
+                      version: 3.6.9
+                  nbformat: 4
+                  nbformat_minor: 4
     TaskPatch:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/TaskNotebooks"
+            $ref: '#/components/schemas/TaskNotebooks'
           example:
             name: string
             description: string
             category: DEFAULT
-            tags: ["DEFAULT"]
+            tags:
+              - DEFAULT
             dataIn: string
             dataOut: string
             docs: string
-            commands: ["cmd"]
-            arguments: ["arg"]
-            image: your-custom-docker-image:tag
-            cpuLimit: "1000m"
-            cpuRequest: "1000m"
-            memoryLimit: "10G"
-            memoryRequest: "10G"
+            commands:
+              - cmd
+            arguments:
+              - arg
+            image: 'your-custom-docker-image:tag'
+            cpuLimit: 1000m
+            cpuRequest: 1000m
+            memoryLimit: 10G
+            memoryRequest: 10G
             deploymentNotebook:
-              {
-                "cells":
-                  [
-                    {
-                      "cell_type": "code",
-                      "execution_count": null,
-                      "metadata": {},
-                      "outputs": [],
-                      "source": [],
-                    },
-                  ],
-                "metadata":
-                  {
-                    "kernelspec":
-                      {
-                        "display_name": "Python 3",
-                        "language": "python",
-                        "name": "python3",
-                      },
-                    "language_info":
-                      {
-                        "codemirror_mode": { "name": "ipython", "version": 3 },
-                        "file_extension": ".py",
-                        "mimetype": "text/x-python",
-                        "name": "python",
-                        "nbconvert_exporter": "python",
-                        "pygments_lexer": "ipython3",
-                        "version": "3.6.9",
-                      },
-                  },
-                "nbformat": 4,
-                "nbformat_minor": 4,
-              }
+              cells:
+                - cell_type: code
+                  execution_count: null
+                  metadata: {}
+                  outputs: []
+                  source: []
+              metadata:
+                kernelspec:
+                  display_name: Python 3
+                  language: python
+                  name: python3
+                language_info:
+                  codemirror_mode:
+                    name: ipython
+                    version: 3
+                  file_extension: .py
+                  mimetype: text/x-python
+                  name: python
+                  nbconvert_exporter: python
+                  pygments_lexer: ipython3
+                  version: 3.6.9
+              nbformat: 4
+              nbformat_minor: 4
             experimentNotebook:
-              {
-                "cells":
-                  [
-                    {
-                      "cell_type": "code",
-                      "execution_count": null,
-                      "metadata": {},
-                      "outputs": [],
-                      "source": [],
-                    },
-                  ],
-                "metadata":
-                  {
-                    "kernelspec":
-                      {
-                        "display_name": "Python 3",
-                        "language": "python",
-                        "name": "python3",
-                      },
-                    "language_info":
-                      {
-                        "codemirror_mode": { "name": "ipython", "version": 3 },
-                        "file_extension": ".py",
-                        "mimetype": "text/x-python",
-                        "name": "python",
-                        "nbconvert_exporter": "python",
-                        "pygments_lexer": "ipython3",
-                        "version": "3.6.9",
-                      },
-                  },
-                "nbformat": 4,
-                "nbformat_minor": 4,
-              }
+              cells:
+                - cell_type: code
+                  execution_count: null
+                  metadata: {}
+                  outputs: []
+                  source: []
+              metadata:
+                kernelspec:
+                  display_name: Python 3
+                  language: python
+                  name: python3
+                language_info:
+                  codemirror_mode:
+                    name: ipython
+                    version: 3
+                  file_extension: .py
+                  mimetype: text/x-python
+                  name: python
+                  nbconvert_exporter: python
+                  pygments_lexer: ipython3
+                  version: 3.6.9
+              nbformat: 4
+              nbformat_minor: 4
     TaskMailing:
       content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                emails:
-                  type: array
-                  items:
-                    type: string
+        application/json:
+          schema:
+            type: object
+            properties:
+              emails:
+                type: array
+                items:
+                  type: string
     Project:
       content:
         application/json:
@@ -2893,22 +4252,23 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: "#/components/schemas/DeploymentExperiments"
-              - $ref: "#/components/schemas/DeploymentTemplate"
-              - $ref: "#/components/schemas/DeploymentCopyFrom"
+              - $ref: '#/components/schemas/DeploymentExperiments'
+              - $ref: '#/components/schemas/DeploymentTemplate'
+              - $ref: '#/components/schemas/DeploymentCopyFrom'
           examples:
             experiments:
               summary: From a list of experiments
               value:
-                experiments: ["3fa85f64-5717-4562-b3fc-2c963f66afa6"]
+                experiments:
+                  - 3fa85f64-5717-4562-b3fc-2c963f66afa6
             template:
               summary: From a template
               value:
-                templateId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                templateId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
             copyFrom:
               summary: From an existing deployment
               value:
-                copyFrom: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                copyFrom: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                 name: string
     DeploymentPatch:
       content:
@@ -2996,12 +4356,12 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/AnyValue"
+            $ref: '#/components/schemas/AnyValue'
     ResponsePost:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Prediction"
+            $ref: '#/components/schemas/Prediction'
     RunPost:
       content:
         application/json:
@@ -3013,20 +4373,19 @@ components:
         application/json:
           schema:
             oneOf:
-              - $ref: "#/components/schemas/TemplateExperiment"
-              - $ref: "#/components/schemas/TemplateDeployment"
+              - $ref: '#/components/schemas/TemplateExperiment'
+              - $ref: '#/components/schemas/TemplateDeployment'
           examples:
             experiment:
               summary: From a experimentId
               value:
                 name: string
-                experimentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                experimentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
             deployment:
               summary: From a deploymentId
               value:
                 name: string
-                deploymentId:
-                  "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                deploymentId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
     TemplatePatch:
       content:
         application/json:
@@ -3045,40 +4404,40 @@ components:
               format: uuid
   responses:
     AnyValue:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/AnyValue"
+            $ref: '#/components/schemas/AnyValue'
         text/plain:
           schema:
             type: string
     Comparison:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Comparison"
+            $ref: '#/components/schemas/Comparison'
     Comparisons:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Comparisons"
+            $ref: '#/components/schemas/Comparisons'
     Task:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Task"
+            $ref: '#/components/schemas/Task'
     Tasks:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Tasks"
+            $ref: '#/components/schemas/Tasks'
     TaskMailing:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
@@ -3087,79 +4446,79 @@ components:
               message:
                 type: string
     Parameters:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Parameters"
+            $ref: '#/components/schemas/Parameters'
     Project:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Project"
+            $ref: '#/components/schemas/Project'
     Projects:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Projects"
+            $ref: '#/components/schemas/Projects'
     Experiment:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Experiment"
+            $ref: '#/components/schemas/Experiment'
     Experiments:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Experiments"
+            $ref: '#/components/schemas/Experiments'
     Deployment:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Deployments"
+            $ref: '#/components/schemas/Deployments'
     Deployments:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Deployments"
+            $ref: '#/components/schemas/Deployments'
     Prediction:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Prediction"
+            $ref: '#/components/schemas/Prediction'
     PredictionInfo:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/PredictionInfo"         
+            $ref: '#/components/schemas/PredictionInfo'
     Operator:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Operator"
+            $ref: '#/components/schemas/Operator'
     Operators:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Operators"
+            $ref: '#/components/schemas/Operators'
     Logs:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Logs"
+            $ref: '#/components/schemas/Logs'
     RunResults:
-      description: ""
+      description: ''
       content:
         application/x-zip-compressed:
           schema:
@@ -3171,49 +4530,49 @@ components:
             type: string
             example: attachment; filename="results.zip"
     Datasets:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Datasets"
+            $ref: '#/components/schemas/Datasets'
     Figures:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Figures"
+            $ref: '#/components/schemas/Figures'
     Metrics:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Metrics"
+            $ref: '#/components/schemas/Metrics'
     Run:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Run"
+            $ref: '#/components/schemas/Run'
     Runs:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Runs"
+            $ref: '#/components/schemas/Runs'
     Template:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Template"
+            $ref: '#/components/schemas/Template'
     Templates:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Templates"
+            $ref: '#/components/schemas/Templates'
     Message:
-      description: ""
+      description: ''
       content:
         application/json:
           schema:
@@ -3224,58 +4583,31 @@ components:
             required:
               - message
     BadRequest:
-      description: ""
+      description: >
+        Bad Request response status code indicates that the server cannot or
+        will not process the request due to something that is perceived to be a
+        client error. A common cause is that the client has sent invalid request
+        values.
       content:
         application/json:
           schema:
             type: object
             properties:
+              code:
+                type: string
               message:
                 type: string
+              status_code:
+                type: integer
+                example: 400
             required:
+              - code
               - message
-    NotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              message:
-                type: string
-                example: "The specified ... does not exist"
-            required:
-              - message
-    InternalServerError:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              message:
-                type: string
-                example: "An internal failure occurred."
-            required:
-              - message
-    ServiceUnavailable:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              message:
-                type: string
-                example: "The service is unavailable. Try your call again."
-            required:
-              - message
-
-    ################################################################################
-    # ERROR RESPONSES
-    ################################################################################
-    ComparisonNotFound:
-      description: ""
+              - status_code
+    Forbidden:
+      description: >
+        Forbidden client error status response code indicates that the server
+        understands the request but refuses to authorize it.
       content:
         application/json:
           schema:
@@ -3283,815 +4615,20 @@ components:
             properties:
               code:
                 type: string
-                example: "ComparisonNotFound"
               message:
                 type: string
-                example: "The specified comparison does not exist."
-              status:
-                type: integer
-                example: 404
-
-    DeploymentNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "DeploymentNotFound"
-              message:
-                type: string
-                example: "The specified deployment does not exist."
-              status:
-                type: integer
-                example: 404
-
-    ExperimentNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "ExperimentNotFound"
-              message:
-                type: string
-                example: "The specified experiment does not exist."
-              status:
-                type: integer
-                example: 404
-
-    MonitoringNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MonitoringNotFound"
-              message:
-                type: string
-                example: "The specified monitoring does not exist."
-              status:
-                type: integer
-                example: 404
-
-    OperatorNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "OperatorNotFound"
-              message:
-                type: string
-                example: "The specified operator does not exist."
-              status:
-                type: integer
-                example: 404
-
-    PredictionNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "PredictionNotFound"
-              message:
-                type: string
-                example: "The specified prediction does not exist."
-              status:
-                type: integer
-                example: 404
-
-    ProjectNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "ProjectNotFound"
-              message:
-                type: string
-                example: "The specified project does not exist."
-              status:
-                type: integer
-                example: 404
-
-    RunNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "RunNotFound"
-              message:
-                type: string
-                example: "The specified run does not exist."
-              status:
-                type: integer
-                example: 404
-
-    TaskNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "TaskNotFound"
-              message:
-                type: string
-                example: "The specified task does not exist."
-              status:
-                type: integer
-                example: 404
-
-    TemplateNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "TemplateNotFound"
-              message:
-                type: string
-                example: "The specified template does not exist."
-              status:
-                type: integer
-                example: 404
-
-    DatasetNotFound:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "DatasetNotFound"
-              message:
-                type: string
-                example: "The specified run does not contain dataset."
-              status:
-                type: integer
-                example: 404
-
-    InternalError:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InternalError"
-              message:
-                type: string
-                example: "The server encountered an internal error. Please retry the request."
-              status:
-                type: integer
-                example: 500
-
-    CannotConnectToDatabase:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "CannotConnectToDatabase"
-              message:
-                type: string
-                example: "Could not connect to database"
-              status:
-                type: integer
-                example: 500
-
-    MissingRequiredFormDataOrJson:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredFormDataOrJson"
-              message:
-                type: string
-                example: "either form-data or json is required"
-              status:
-                type: integer
-                example: 400
-
-    InvalidDataset:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidDataset"
-              message:
-                type: string
-                example: "a valid dataset is required"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredDatasetOrFile:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredDatasetOrFile"
-              message:
-                type: string
-                example: "either dataset name or file is required"
-              status:
-                type: integer
-                example: 400
-
-    InvalidOrderBy:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidOrderBy"
-              message:
-                type: string
-                example: "Invalid order argument"
-              status:
-                type: integer
-                example: 400
-
-    ProjectNameExists:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "ProjectNameExists"
-              message:
-                type: string
-                example: "a project with that name already exists"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredProjectId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredProjectId"
-              message:
-                type: string
-                example: "inform at least one project"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredTemplateName:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredTemplateName"
-              message:
-                type: string
-                example: "name is required"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredExperimentIdOrDeploymentId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredExperimentIdOrDeploymentId"
-              message:
-                type: string
-                example: "experimentId or deploymentId needed to create template."
-              status:
-                type: integer
-                example: 400
-
-    TemplateNameExists:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "TemplateNameExists"
-              message:
-                type: string
-                example: "a template with that name already exists"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredTemplateId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredTemplateId"
-              message:
-                type: string
-                example: "inform at least one template"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredExperimentsOrTemplateIdOrCopyFrom:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredExperimentsOrTemplateIdOrCopyFrom"
-              message:
-                type: string
-                example: "either experiments, templateId or copyFrom is required"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredDeploymentName:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredDeploymentName"
-              message:
-                type: string
-                example: "name is required to duplicate deployment"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredOperatorId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredOperatorId"
-              message:
-                type: string
-                example: "Necessary at least one operator."
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredDataSourceOperatorId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredDataSourceOperatorId"
-              message:
-                type: string
-                example: "Necessary at least one operator that is not a data source."
-              status:
-                type: integer
-                example: 400
-
-    InvalidExperiments:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidExperiments"
-              message:
-                type: string
-                example: "some experiments do not exist"
-              status:
-                type: integer
-                example: 400
-
-    InvalidDeploymentId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidDeploymentId"
-              message:
-                type: string
-                example: "source deployment does not exist"
-              status:
-                type: integer
-                example: 400
-
-    InvalidRunId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidRunId"
-              message:
-                type: string
-                example: "Not a failed run"
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredExperimentName:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredExperimentName"
-              message:
-                type: string
-                example: "name is required"
-              status:
-                type: integer
-                example: 400
-
-    DeploymentNameExists:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "DeploymentNameExists"
-              message:
-                type: string
-                example: "a deployment with that name already exists"
-              status:
-                type: integer
-                example: 400
-
-    ExperimentNameExists:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "ExperimentNameExists"
-              message:
-                type: string
-                example: "an experiment with that name already exists"
-              status:
-                type: integer
-                example: 400
-
-    InvalidExperimentId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidExperimentId"
-              message:
-                type: string
-                example: "source experiment does not exist"
-              status:
-                type: integer
-                example: 400
-
-    InvalidTemplateId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidTemplateId"
-              message:
-                type: string
-                example: "The specified template does not exist"
-              status:
-                type: integer
-                example: 400
-
-    CannotCreateLogStream:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "CannotConnectToLogStream"
-              message:
-                type: string
-                example: "Unable to create log stream. No active pod available."
-              status:
-                type: integer
-                example: 500
-
-    CannotCreateNamespacedPod:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "CannotCreateNamespacedPod"
-              message:
-                type: string
-                example: "Error while trying to create pod: {message}"
-              status:
-                type: integer
-                example: 500
-
-    MissingRequiredTaskId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredTaskId"
-              message:
-                type: string
-                example: "taskId is required"
-              status:
-                type: integer
-                example: 400
-
-    InvalidOperatorRequestBody:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidOperatorRequestBody"
-              message:
-                type: string
-                example: "Operator cannot contain an experiment and a deployment simultaneously"
-              status:
-                type: integer
-                example: 400
-
-    InvalidParameters:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidParameters"
-              message:
-                type: string
-                example: "The specified parameters are not valid"
-              status:
-                type: integer
-                example: 400
-
-    InvalidDependencies:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidDependencies"
-              message:
-                type: string
-                example: "The specified dependencies are not valid."
-              status:
-                type: integer
-                example: 400
-
-    InvalidCyclicalDependencies:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidCyclicalDependencies"
-              message:
-                type: string
-                example: "Cyclical dependencies."
-              status:
-                type: integer
-                example: 400
-
-    MissingRequiredNotebookOrTaskId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "MissingRequiredNotebookOrTaskId"
-              message:
-                type: string
-                example: "Either provide notebooks or a task to copy from"
-              status:
-                type: integer
-                example: 400
-
-    TaskNameExists:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: ""
-              message:
-                type: string
-                example: "a task with that name already exists"
-              status:
-                type: integer
-                example: 400
-
-    InvalidTaskId:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidTaskId"
-              message:
-                type: string
-                example: "source task does not exist"
-              status:
-                type: integer
-                example: 400
-
-    InvalidCategory:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidCategory"
-              message:
-                type: string
-                example: "Invalid category. Choose any of {valid_categories}"
-              status:
-                type: integer
-                example: 400
-
-    InvalidDockerImageName:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "InvalidDockerImageName"
-              message:
-                type: string
-                example: "invalid docker image name"
-              status:
-                type: integer
-                example: 400
-
-    TaskProtectedFromDeletion:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "TaskProtectedFromDeletion"
-              message:
-                type: string
-                example: "Task related to an operator"
-              status:
+              status_code:
                 type: integer
                 example: 403
-
-    CannotConnectToCluster:
-      description: ""
+            required:
+              - code
+              - message
+              - status_code
+    NotFound:
+      description: >
+        Not Found client error response code indicates that the server can't
+        find the requested resource. A common cause is that a provided ID does
+        not exist in the database.
       content:
         application/json:
           schema:
@@ -4099,16 +4636,21 @@ components:
             properties:
               code:
                 type: string
-                example: "CannotConnectToCluster"
               message:
                 type: string
-                example: "Failed to connect to cluster."
-              status:
+              status_code:
                 type: integer
-                example: 400
-
-    CannotCreatePersistentVolumeClaim:
-      description: ""
+                example: 404
+            required:
+              - code
+              - message
+              - status_code
+    InternalServerError:
+      description: >
+        Internal Server Error server error response code indicates that the
+        server encountered an unexpected condition that prevented it from
+        fulfilling the request. This error response is a generic "catch-all"
+        response.
       content:
         application/json:
           schema:
@@ -4116,44 +4658,289 @@ components:
             properties:
               code:
                 type: string
-                example: "CannotCreatePersistentVolumeClaim"
               message:
                 type: string
-                example: "Error while trying to create persistent volume claim: {message}"
-              status:
-                type: integer
-                example: 400
-
-    CannotPatchNotebookServer:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "CannotPatchNotebookServer"
-              message:
-                type: string
-                example: "Error while trying to patch notebook server: {message}"
-              status:
-                type: integer
-                example: 400
-
-    CannotRetrieveContainerLogs:
-      description: ""
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              code:
-                type: string
-                example: "CannotRetrieveContainerLogs"
-              message:
-                type: string
-                example: "Error while trying to retrieve container's log: {message}"
-              status:
+              status_code:
                 type: integer
                 example: 500
+            required:
+              - code
+              - message
+              - status_code
+    ServiceUnavailable:
+      description: >
+        Service Unavailable server error response code indicates that the server
+        is not ready to handle the request. A common cause is that the database
+        is not available or overloaded.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+              message:
+                type: string
+              status_code:
+                type: integer
+                example: 503
+            required:
+              - code
+              - message
+              - status_code
+  examples:
+    CannotConnectToDatabase:
+      value:
+        code: CannotConnectToDatabase
+        message: Could not connect to database
+        status_code: 500
+    MissingRequiredFormDataOrJson:
+      value:
+        code: MissingRequiredFormDataOrJson
+        message: either form-data or json is required
+        status_code: 400
+    InvalidDataset:
+      value:
+        code: InvalidDataset
+        message: a valid dataset is required
+        status_code: 400
+    MissingRequiredDatasetOrFile:
+      value:
+        code: MissingRequiredDatasetOrFile
+        message: either dataset name or file is required
+        status_code: 400
+    InvalidOrderBy:
+      value:
+        code: InvalidOrderBy
+        message: Invalid order argument
+        status_code: 400
+    ProjectNameExists:
+      value:
+        code: ProjectNameExists
+        message: a project with that name already exists
+        status_code: 400
+    MissingRequiredProjectId:
+      value:
+        code: MissingRequiredProjectId
+        message: inform at least one project
+        status_code: 400
+    MissingRequiredTemplateName:
+      value:
+        code: MissingRequiredTemplateName
+        message: name is required
+        status_code: 400
+    MissingRequiredExperimentIdOrDeploymentId:
+      value:
+        code: MissingRequiredExperimentIdOrDeploymentId
+        message: experimentId or deploymentId needed to create template.
+        status_code: 400
+    TemplateNameExists:
+      value:
+        code: TemplateNameExists
+        message: a template with that name already exists
+        status_code: 400
+    MissingRequiredTemplateId:
+      value:
+        code: MissingRequiredTemplateId
+        message: inform at least one template
+        status_code: 400
+    MissingRequiredExperimentsOrTemplateIdOrCopyFrom:
+      value:
+        code: MissingRequiredExperimentsOrTemplateIdOrCopyFrom
+        message: 'either experiments, templateId or copyFrom is required'
+        status_code: 400
+    MissingRequiredDeploymentName:
+      value:
+        code: MissingRequiredDeploymentName
+        message: name is required to duplicate deployment
+        status_code: 400
+    MissingRequiredOperatorId:
+      value:
+        code: MissingRequiredOperatorId
+        message: Necessary at least one operator.
+        status_code: 400
+    MissingRequiredDataSourceOperatorId:
+      value:
+        code: MissingRequiredDataSourceOperatorId
+        message: Necessary at least one operator that is not a data source.
+        status_code: 400
+    InvalidExperiments:
+      value:
+        code: InvalidExperiments
+        message: some experiments do not exist
+        status_code: 400
+    InvalidDeploymentId:
+      value:
+        code: InvalidDeploymentId
+        message: source deployment does not exist
+        status_code: 400
+    InvalidRunId:
+      value:
+        code: InvalidRunId
+        message: Not a failed run
+        status_code: 400
+    MissingRequiredExperimentName:
+      value:
+        code: MissingRequiredExperimentName
+        message: name is required
+        status_code: 400
+    DeploymentNameExists:
+      value:
+        code: DeploymentNameExists
+        message: a deployment with that name already exists
+        status_code: 400
+    ExperimentNameExists:
+      value:
+        code: ExperimentNameExists
+        message: an experiment with that name already exists
+        status_code: 400
+    InvalidExperimentId:
+      value:
+        code: InvalidExperimentId
+        message: source experiment does not exist
+        status_code: 400
+    InvalidTemplateId:
+      value:
+        code: InvalidTemplateId
+        message: The specified template does not exist
+        status_code: 400
+    CannotCreateLogStream:
+      value:
+        code: CannotCreateLogStream
+        message: Unable to create log stream. No active pod available.
+        status_code: 500
+    CannotCreateNamespacedPod:
+      value:
+        code: CannotCreateNamespacedPod
+        message: 'Error while trying to create pod: {message}'
+        status_code: 500
+    MissingRequiredTaskId:
+      value:
+        code: MissingRequiredTaskId
+        message: taskId is required
+        status_code: 400
+    InvalidOperatorRequestBody:
+      value:
+        code: InvalidOperatorRequestBody
+        message: Operator cannot contain an experiment and a deployment simultaneously
+        status_code: 400
+    InvalidParameters:
+      value:
+        code: InvalidParameters
+        message: The specified parameters are not valid
+        status_code: 400
+    InvalidDependencies:
+      value:
+        code: InvalidDependencies
+        message: The specified dependencies are not valid.
+        status_code: 400
+    InvalidCyclicalDependencies:
+      value:
+        code: InvalidCyclicalDependencies
+        message: Cyclical dependencies.
+        status_code: 400
+    MissingRequiredNotebookOrTaskId:
+      value:
+        code: MissingRequiredNotebookOrTaskId
+        message: Either provide notebooks or a task to copy from
+        status_code: 400
+    TaskNameExists:
+      value:
+        code: TaskNameExists
+        message: a task with that name already exists
+        status_code: 400
+    InvalidTaskId:
+      value:
+        code: InvalidTaskId
+        message: source task does not exist
+        status_code: 400
+    InvalidCategory:
+      value:
+        code: InvalidCategory
+        message: 'Invalid category. Choose any of {valid_categories}'
+        status_code: 400
+    InvalidDockerImageName:
+      value:
+        code: InvalidDockerImageName
+        message: invalid docker image name
+        status_code: 400
+    TaskProtectedFromDeletion:
+      value:
+        code: TaskProtectedFromDeletion
+        message: Task related to an operator
+        status_code: 403
+    CannotConnectToCluster:
+      value:
+        code: CannotConnectToCluster
+        message: Failed to connect to cluster.
+        status_code: 500
+    CannotCreatePersistentVolumeClaim:
+      value:
+        code: CannotCreatePersistentVolumeClaim
+        message: 'Error while trying to create persistent volume claim: {message}'
+        status_code: 500
+    CannotPatchNotebookServer:
+      value:
+        code: CannotPatchNotebookServer
+        message: 'Error while trying to patch notebook server: {message}'
+        status_code: 500
+    CannotRetrieveContainerLogs:
+      value:
+        code: CannotRetrieveContainerLogs
+        message: 'Error while trying to retrieve container''s log: {message}'
+        status_code: 500
+    ComparisonNotFound:
+      value:
+        code: ComparisonNotFound
+        message: The specified comparison does not exist.
+        status_code: 404
+    DeploymentNotFound:
+      value:
+        code: DeploymentNotFound
+        message: The specified deployment does not exist.
+        status_code: 404
+    ExperimentNotFound:
+      value:
+        code: ExperimentNotFound
+        message: The specified experiment does not exist.
+        status_code: 404
+    MonitoringNotFound:
+      value:
+        code: MonitoringNotFound
+        message: The specified monitoring does not exist.
+        status_code: 404
+    OperatorNotFound:
+      value:
+        code: OperatorNotFound
+        message: The specified operator does not exist.
+        status_code: 404
+    PredictionNotFound:
+      value:
+        code: PredictionNotFound
+        message: The specified prediction does not exist.
+        status_code: 404
+    ProjectNotFound:
+      value:
+        code: ProjectNotFound
+        message: The specified project does not exist.
+        status_code: 404
+    RunNotFound:
+      value:
+        code: RunNotFound
+        message: The specified run does not exist.
+        status_code: 404
+    TaskNotFound:
+      value:
+        code: TaskNotFound
+        message: The specified task does not exist.
+        status_code: 404
+    TemplateNotFound:
+      value:
+        code: TemplateNotFound
+        message: The specified template does not exist.
+        status_code: 404
+    DatasetNotFound:
+      value:
+        code: DatasetNotFound
+        message: The specified run does not contain dataset.
+        status_code: 404

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3444,6 +3444,23 @@ components:
                 type: integer
                 example: 404
 
+    DatasetNotFound:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "DatasetNotFound"
+              message:
+                type: string
+                example: "The specified run does not contain dataset."
+              status:
+                type: integer
+                example: 404
+
     InternalError:
       description: ""
       content:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3784,6 +3784,23 @@ components:
                 type: integer
                 example: 400
 
+    DeploymentNameExists:
+      description: ""
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "DeploymentNameExists"
+              message:
+                type: string
+                example: "a deployment with that name already exists"
+              status:
+                type: integer
+                example: 400
+
     ExperimentNameExists:
       description: ""
       content:

--- a/projects/api/healthcheck.py
+++ b/projects/api/healthcheck.py
@@ -26,9 +26,15 @@ def handle_healthcheck(session: Session = Depends(database.session_scope)):
     Returns
     -------
     str
+
+    Raises
+    ------
+    ServiceUnavailable
     """
     try:
         session.query(sqlalchemy.false()).filter(sqlalchemy.false()).all()
     except OperationalError:
-        raise ServiceUnavailable("Could not connect to database")
+        raise ServiceUnavailable(
+            code="CannotConnectToDatabase", message="Could not connect to database"
+        )
     return "Sucessfully connected to db"

--- a/projects/api/main.py
+++ b/projects/api/main.py
@@ -67,15 +67,20 @@ async def handle_errors(request: Request, exception: Exception):
 
     Parameters
     ----------
+    request : Request
     exception : Exception
 
     Returns
     -------
-    str
+    JSONResponse
     """
     return JSONResponse(
-        status_code=exception.code,
-        content={"message": exception.message},
+        status_code=exception.status_code,
+        content={
+            "code": exception.code,
+            "message": exception.message,
+            "status_code": exception.status_code,
+        },
     )
 
 

--- a/projects/api/main.py
+++ b/projects/api/main.py
@@ -79,7 +79,6 @@ async def handle_errors(request: Request, exception: Exception):
         content={
             "code": exception.code,
             "message": exception.message,
-            "status_code": exception.status_code,
         },
     )
 

--- a/projects/api/predictions.py
+++ b/projects/api/predictions.py
@@ -70,7 +70,10 @@ async def handle_post_prediction(
         try:
             kwargs = await request.json()
         except JSONDecodeError:
-            raise BadRequest("either form-data or json is required")
+            raise BadRequest(
+                code="MissingRequiredFormDataOrJson",
+                message="either form-data or json is required",
+            )
 
     prediction_controller = PredictionController(session, background_tasks)
     prediction = prediction_controller.create_prediction(

--- a/projects/controllers/comparisons.py
+++ b/projects/controllers/comparisons.py
@@ -115,8 +115,8 @@ class ComparisonController:
             )
             if stored_experiment is None:
                 raise BadRequest(
-                    code="ExperimentNotFound",
-                    message="The specified experiment does not exist",
+                    code="InvalidExperimentId",
+                    message="source experiment does not exist",
                 )
 
         update_data = comparison.dict(exclude_unset=True)

--- a/projects/controllers/comparisons.py
+++ b/projects/controllers/comparisons.py
@@ -7,7 +7,9 @@ from projects.controllers.experiments import ExperimentController
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, NotFound
 
-NOT_FOUND = NotFound("The specified comparison does not exist")
+NOT_FOUND = NotFound(
+    code="ComparisonNotFound", message="The specified comparison does not exist"
+)
 
 
 class ComparisonController:
@@ -27,9 +29,12 @@ class ComparisonController:
         ------
         NotFound
         """
-        exists = self.session.query(models.Comparison.uuid) \
-            .filter_by(uuid=comparison_id) \
-            .scalar() is not None
+        exists = (
+            self.session.query(models.Comparison.uuid)
+            .filter_by(uuid=comparison_id)
+            .scalar()
+            is not None
+        )
 
         if not exists:
             raise NOT_FOUND
@@ -51,10 +56,12 @@ class ComparisonController:
         NotFound
             When project_id does not exist.
         """
-        comparisons = self.session.query(models.Comparison) \
-            .filter_by(project_id=project_id) \
-            .order_by(models.Comparison.created_at.asc()) \
+        comparisons = (
+            self.session.query(models.Comparison)
+            .filter_by(project_id=project_id)
+            .order_by(models.Comparison.created_at.asc())
             .all()
+        )
 
         return schemas.ComparisonList.from_orm(comparisons, len(comparisons))
 
@@ -77,7 +84,9 @@ class ComparisonController:
 
         return schemas.Comparison.from_orm(comparison)
 
-    def update_comparison(self, comparison: schemas.ComparisonUpdate, project_id: str, comparison_id: str):
+    def update_comparison(
+        self, comparison: schemas.ComparisonUpdate, project_id: str, comparison_id: str
+    ):
         """
         Updates a comparison in our database.
 
@@ -101,14 +110,21 @@ class ComparisonController:
         self.raise_if_comparison_does_not_exist(comparison_id)
 
         if comparison.experiment_id:
-            stored_experiment = self.session.query(models.Experiment).get(comparison.experiment_id)
+            stored_experiment = self.session.query(models.Experiment).get(
+                comparison.experiment_id
+            )
             if stored_experiment is None:
-                raise BadRequest("The specified experiment does not exist")
+                raise BadRequest(
+                    code="ExperimentNotFound",
+                    message="The specified experiment does not exist",
+                )
 
         update_data = comparison.dict(exclude_unset=True)
         update_data.update({"updated_at": datetime.utcnow()})
 
-        self.session.query(models.Comparison).filter_by(uuid=comparison_id).update(update_data)
+        self.session.query(models.Comparison).filter_by(uuid=comparison_id).update(
+            update_data
+        )
         self.session.commit()
 
         comparison = self.session.query(models.Comparison).get(comparison_id)

--- a/projects/controllers/deployments/deployments.py
+++ b/projects/controllers/deployments/deployments.py
@@ -13,7 +13,9 @@ from projects.controllers.utils import uuid_alpha
 from projects.controllers.tasks import TaskController
 from projects.exceptions import BadRequest, NotFound
 
-NOT_FOUND = NotFound("The specified deployment does not exist")
+NOT_FOUND = NotFound(
+    code="DeploymentNotFound", message="The specified deployment does not exist"
+)
 
 # Distance on the X axis from the leftmost operator
 DATASET_OPERATOR_DISTANCE = 300

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -13,7 +13,7 @@ from projects.kubernetes.kube_config import load_kube_config
 from projects.kubernetes.seldon import get_seldon_deployment_url
 
 
-NOT_FOUND = NotFound("The specified run does not exist")
+NOT_FOUND = NotFound(code="RunNotFound", message="The specified run does not exist")
 
 
 class RunController:
@@ -34,8 +34,7 @@ class RunController:
         NotFound
         """
         try:
-            kfp_runs.get_run(experiment_id=deployment_id,
-                             run_id=run_id)
+            kfp_runs.get_run(experiment_id=deployment_id, run_id=run_id)
         except (ApiException, ValueError):
             raise NOT_FOUND
 
@@ -73,16 +72,19 @@ class RunController:
         """
         deployment = self.session.query(models.Deployment).get(deployment_id)
         url = get_seldon_deployment_url(deployment_id)
-        self.session.query(models.Deployment) \
-            .filter_by(uuid=deployment_id) \
-            .update({"url": url})
+        self.session.query(models.Deployment).filter_by(uuid=deployment_id).update(
+            {"url": url}
+        )
         self.session.commit()
 
         run = self.get_run(deployment_id)
 
         # Uses empty run if a deployment does not have a run
         if not run:
-            operators = dict((o.uuid, {"taskId": o.task.uuid, "parameters": {}}) for o in deployment.operators)
+            operators = dict(
+                (o.uuid, {"taskId": o.task.uuid, "parameters": {}})
+                for o in deployment.operators
+            )
             run = {
                 "uuid": "",
                 "operators": operators,
@@ -111,18 +113,23 @@ class RunController:
             When any of project_id, or deployment_id does not exist.
         """
         if deployment is None:
-            raise NotFound("The specified deployment does not exist")
+            raise NotFound(
+                code="DeploymentNotFound",
+                message="The specified deployment does not exist",
+            )
 
         # Removes operators that don't have a deployment_notebook (eg. Upload de Dados).
         # Then, fix dependencies in their children.
         operators = self.remove_non_deployable_operators(deployment.operators)
 
         try:
-            run = kfp_runs.start_run(operators=operators,
-                                     project_id=deployment.project_id,
-                                     experiment_id=deployment.experiment_id,
-                                     deployment_id=deployment.uuid,
-                                     deployment_name=deployment.name)
+            run = kfp_runs.start_run(
+                operators=operators,
+                project_id=deployment.project_id,
+                experiment_id=deployment.experiment_id,
+                deployment_id=deployment.uuid,
+                deployment_name=deployment.name,
+            )
         except ValueError as e:
             raise BadRequest(str(e))
 
@@ -177,7 +184,7 @@ class RunController:
             "machinelearning.seldon.io",
             "v1",
             KF_PIPELINES_NAMESPACE,
-            "seldondeployments"
+            "seldondeployments",
         )
         deployments_objects = custom_objects["items"]
 
@@ -193,7 +200,9 @@ class RunController:
         deployment_run = get_deployment_runs(deployment_id)
 
         if not deployment_run:
-            raise NotFound("Deployment run does not exist.")
+            raise NotFound(
+                code="RunNotFound", message="The specified run does not exist."
+            )
 
         kfp_client().runs.delete_run(deployment_run["runId"])
 
@@ -218,8 +227,12 @@ class RunController:
         If the non-deployable operator is dependent on another operator, it will be
         removed from that operator's dependency list.
         """
-        deployable_operators = [o for o in operators if o.task.deployment_notebook_path is not None]
-        non_deployable_operators = self.get_non_deployable_operators(operators, deployable_operators)
+        deployable_operators = [
+            o for o in operators if o.task.deployment_notebook_path is not None
+        ]
+        non_deployable_operators = self.get_non_deployable_operators(
+            operators, deployable_operators
+        )
 
         for operator in deployable_operators:
             dependencies = set(operator.dependencies)

--- a/projects/controllers/deployments/runs/runs.py
+++ b/projects/controllers/deployments/runs/runs.py
@@ -130,8 +130,11 @@ class RunController:
                 deployment_id=deployment.uuid,
                 deployment_name=deployment.name,
             )
-        except ValueError as e:
-            raise BadRequest(str(e))
+        except ValueError:
+            raise BadRequest(
+                code="MissingRequiredOperatorId",
+                message=f"Necessary at least one operator.",
+            )
 
         # Remove the object from the operator session in order not to update the database,
         # Just need to remove the dependencies for the runs.

--- a/projects/controllers/experiments/experiments.py
+++ b/projects/controllers/experiments/experiments.py
@@ -191,7 +191,7 @@ class ExperimentController:
         )
         if stored_experiment and stored_experiment.uuid != experiment_id:
             raise BadRequest(
-                code="InvalidExperimentId",
+                code="ExperimentNameExists",
                 message="an experiment with that name already exists",
             )
 
@@ -351,7 +351,8 @@ class ExperimentController:
 
         if template is None:
             raise BadRequest(
-                code="TemplateNotFound", message="The specified template does not exist"
+                code="InvalidTemplateId",
+                message="The specified template does not exist",
             )
 
         # remove operators

--- a/projects/controllers/experiments/experiments.py
+++ b/projects/controllers/experiments/experiments.py
@@ -10,7 +10,9 @@ from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, NotFound
 
 
-NOT_FOUND = NotFound("The specified experiment does not exist")
+NOT_FOUND = NotFound(
+    code="ExperimentNotFound", message="The specified experiment does not exist"
+)
 
 
 class ExperimentController:
@@ -30,12 +32,18 @@ class ExperimentController:
         ------
         NotFound
         """
-        exists = self.session.query(models.Experiment.uuid) \
-            .filter_by(uuid=experiment_id) \
-            .scalar() is not None
+        exists = (
+            self.session.query(models.Experiment.uuid)
+            .filter_by(uuid=experiment_id)
+            .scalar()
+            is not None
+        )
 
         if not exists:
-            raise NotFound("The specified experiment does not exist")
+            raise NotFound(
+                code="ExperimentNotFound",
+                message="The specified experiment does not exist",
+            )
 
     def list_experiments(self, project_id: str):
         """
@@ -54,10 +62,12 @@ class ExperimentController:
         NotFound
             When project_id does not exist.
         """
-        experiments = self.session.query(models.Experiment) \
-            .filter_by(project_id=project_id) \
-            .order_by(models.Experiment.position.asc()) \
+        experiments = (
+            self.session.query(models.Experiment)
+            .filter_by(project_id=project_id)
+            .order_by(models.Experiment.position.asc())
             .all()
+        )
 
         return schemas.ExperimentList.from_orm(experiments, len(experiments))
 
@@ -86,23 +96,31 @@ class ExperimentController:
         if not isinstance(experiment.name, str):
             raise BadRequest("name is required")
 
-        stored_experiment = self.session.query(models.Experiment) \
-            .filter(models.Experiment.project_id == project_id) \
-            .filter_by(name=experiment.name) \
+        stored_experiment = (
+            self.session.query(models.Experiment)
+            .filter(models.Experiment.project_id == project_id)
+            .filter_by(name=experiment.name)
             .first()
+        )
         if stored_experiment:
             raise BadRequest("an experiment with that name already exists")
 
         if experiment.copy_from:
-            experiment = self.copy_experiment(experiment=experiment, project_id=project_id)
+            experiment = self.copy_experiment(
+                experiment=experiment, project_id=project_id
+            )
         else:
-            experiment = models.Experiment(uuid=uuid_alpha(), name=experiment.name, project_id=project_id)
+            experiment = models.Experiment(
+                uuid=uuid_alpha(), name=experiment.name, project_id=project_id
+            )
             self.session.add(experiment)
             self.session.flush()
 
-        self.fix_positions(project_id=project_id,
-                           experiment_id=experiment.uuid,
-                           new_position=sys.maxsize)  # will add to end of list
+        self.fix_positions(
+            project_id=project_id,
+            experiment_id=experiment.uuid,
+            new_position=sys.maxsize,
+        )  # will add to end of list
 
         self.session.commit()
         self.session.refresh(experiment)
@@ -134,7 +152,9 @@ class ExperimentController:
 
         return schemas.Experiment.from_orm(experiment)
 
-    def update_experiment(self, experiment: schemas.ExperimentUpdate, project_id: str, experiment_id: str):
+    def update_experiment(
+        self, experiment: schemas.ExperimentUpdate, project_id: str, experiment_id: str
+    ):
         """
         Updates an experiment in our database and adjusts the position of others.
 
@@ -158,25 +178,33 @@ class ExperimentController:
         """
         self.raise_if_experiment_does_not_exist(experiment_id)
 
-        stored_experiment = self.session.query(models.Experiment) \
-            .filter(models.Experiment.project_id == project_id) \
-            .filter_by(name=experiment.name) \
+        stored_experiment = (
+            self.session.query(models.Experiment)
+            .filter(models.Experiment.project_id == project_id)
+            .filter_by(name=experiment.name)
             .first()
+        )
         if stored_experiment and stored_experiment.uuid != experiment_id:
             raise BadRequest("an experiment with that name already exists")
 
         if experiment.template_id:
-            return self.update_experiment_from_template(experiment=experiment, experiment_id=experiment_id)
+            return self.update_experiment_from_template(
+                experiment=experiment, experiment_id=experiment_id
+            )
 
         update_data = experiment.dict(exclude_unset=True)
         update_data.update({"updated_at": datetime.utcnow()})
 
-        self.session.query(models.Experiment).filter_by(uuid=experiment_id).update(update_data)
+        self.session.query(models.Experiment).filter_by(uuid=experiment_id).update(
+            update_data
+        )
 
         if experiment.position:
-            self.fix_positions(project_id=project_id,
-                               experiment_id=experiment_id,
-                               new_position=experiment.position)
+            self.fix_positions(
+                project_id=project_id,
+                experiment_id=experiment_id,
+                new_position=experiment.position,
+            )
 
         self.session.commit()
 
@@ -208,19 +236,19 @@ class ExperimentController:
             raise NOT_FOUND
 
         # remove comparisons
-        self.session.query(models.Comparison) \
-            .filter(models.Comparison.experiment_id == experiment_id) \
-            .delete()
+        self.session.query(models.Comparison).filter(
+            models.Comparison.experiment_id == experiment_id
+        ).delete()
 
         # remove experiment operators
-        self.session.query(models.Operator) \
-            .filter(models.Operator.experiment_id == experiment_id) \
-            .delete()
+        self.session.query(models.Operator).filter(
+            models.Operator.experiment_id == experiment_id
+        ).delete()
 
         # update deployments experiment id to None
-        self.session.query(models.Deployment) \
-            .filter(models.Deployment.experiment_id == experiment_id) \
-            .update({"experiment_id": None})
+        self.session.query(models.Deployment).filter(
+            models.Deployment.experiment_id == experiment_id
+        ).update({"experiment_id": None})
 
         self.session.delete(experiment)
         self.session.flush()
@@ -248,12 +276,16 @@ class ExperimentController:
         BadRequest
             When copy_from does not exist.
         """
-        stored_experiment = self.session.query(models.Experiment).get(experiment.copy_from)
+        stored_experiment = self.session.query(models.Experiment).get(
+            experiment.copy_from
+        )
 
         if stored_experiment is None:
             raise BadRequest("source experiment does not exist")
 
-        experiment = models.Experiment(uuid=uuid_alpha(), name=experiment.name, project_id=project_id)
+        experiment = models.Experiment(
+            uuid=uuid_alpha(), name=experiment.name, project_id=project_id
+        )
         self.session.add(experiment)
         self.session.flush()
 
@@ -269,7 +301,9 @@ class ExperimentController:
                 position_x=stored_operator.position_x,
                 position_y=stored_operator.position_y,
             )
-            operator = self.operator_controller.create_operator(operator=operator, project_id=project_id, experiment_id=experiment.uuid)
+            operator = self.operator_controller.create_operator(
+                operator=operator, project_id=project_id, experiment_id=experiment.uuid
+            )
 
             copies_map[stored_operator.uuid] = {
                 "copy_uuid": operator.uuid,
@@ -279,16 +313,22 @@ class ExperimentController:
         # sets dependencies on new operators
         for _, value in copies_map.items():
             operator = schemas.OperatorUpdate(
-                dependencies=[copies_map[d]["copy_uuid"] for d in value["dependencies"]],
+                dependencies=[
+                    copies_map[d]["copy_uuid"] for d in value["dependencies"]
+                ],
             )
-            self.operator_controller.update_operator(project_id=project_id,
-                                                     experiment_id=experiment.uuid,
-                                                     operator_id=value["copy_uuid"],
-                                                     operator=operator)
+            self.operator_controller.update_operator(
+                project_id=project_id,
+                experiment_id=experiment.uuid,
+                operator_id=value["copy_uuid"],
+                operator=operator,
+            )
 
         return experiment
 
-    def update_experiment_from_template(self, experiment: schemas.ExperimentUpdate, experiment_id: str):
+    def update_experiment_from_template(
+        self, experiment: schemas.ExperimentUpdate, experiment_id: str
+    ):
         """
         Recreates the operators of experiment using a template.
 
@@ -300,12 +340,14 @@ class ExperimentController:
         template = self.session.query(models.Template).get(experiment.template_id)
 
         if template is None:
-            raise BadRequest("The specified template does not exist")
+            raise BadRequest(
+                code="TemplateNotFound", message="The specified template does not exist"
+            )
 
         # remove operators
-        self.session.query(models.Operator) \
-            .filter(models.Operator.experiment_id == experiment_id) \
-            .delete()
+        self.session.query(models.Operator).filter(
+            models.Operator.experiment_id == experiment_id
+        ).delete()
 
         # save the operators created to get the created_uuid to use on dependencies
         operators_created = []
@@ -314,7 +356,9 @@ class ExperimentController:
             task_dependencies = task["dependencies"]
             if len(task_dependencies) > 0:
                 for d in task_dependencies:
-                    op_created = next((o for o in operators_created if o["uuid"] == d), None)
+                    op_created = next(
+                        (o for o in operators_created if o["uuid"] == d), None
+                    )
                     dependencies.append(op_created["created_uuid"])
 
             operator_id = uuid_alpha()
@@ -338,7 +382,12 @@ class ExperimentController:
 
         return schemas.Experiment.from_orm(experiment)
 
-    def fix_positions(self, project_id: str, experiment_id: Optional[str] = None, new_position: Optional[int] = None):
+    def fix_positions(
+        self,
+        project_id: str,
+        experiment_id: Optional[str] = None,
+        new_position: Optional[int] = None,
+    ):
         """
         Reorders the experiments in a project when an experiment is updated/deleted.
 
@@ -349,11 +398,13 @@ class ExperimentController:
         new_position : int
             The position where the experiment is shown.
         """
-        other_experiments = self.session.query(models.Experiment) \
-            .filter_by(project_id=project_id) \
-            .filter(models.Experiment.uuid != experiment_id) \
-            .order_by(models.Experiment.position.asc()) \
+        other_experiments = (
+            self.session.query(models.Experiment)
+            .filter_by(project_id=project_id)
+            .filter(models.Experiment.uuid != experiment_id)
+            .order_by(models.Experiment.position.asc())
             .all()
+        )
 
         if experiment_id is not None:
             experiment = self.session.query(models.Experiment).get(experiment_id)
@@ -361,7 +412,7 @@ class ExperimentController:
 
         for index, experiment in enumerate(other_experiments):
             data = {"position": index}
-            is_last = (index == len(other_experiments) - 1)
+            is_last = index == len(other_experiments) - 1
             # if experiment_id WAS NOT informed, then set the higher position as is_active=True
             if experiment_id is None and is_last:
                 data["is_active"] = True
@@ -371,6 +422,6 @@ class ExperimentController:
             else:
                 data["is_active"] = False
 
-            self.session.query(models.Experiment) \
-                .filter_by(uuid=experiment.uuid) \
-                .update(data)
+            self.session.query(models.Experiment).filter_by(
+                uuid=experiment.uuid
+            ).update(data)

--- a/projects/controllers/experiments/experiments.py
+++ b/projects/controllers/experiments/experiments.py
@@ -90,14 +90,8 @@ class ExperimentController:
         NotFound
             When project_id does not exist.
         BadRequest
-            When name is not a str instance.
             When name is already the name of another experiment.
         """
-        if not isinstance(experiment.name, str):
-            raise BadRequest(
-                code="MissingRequiredTemplateName", message="name is required"
-            )
-
         stored_experiment = (
             self.session.query(models.Experiment)
             .filter(models.Experiment.project_id == project_id)

--- a/projects/controllers/experiments/experiments.py
+++ b/projects/controllers/experiments/experiments.py
@@ -94,7 +94,9 @@ class ExperimentController:
             When name is already the name of another experiment.
         """
         if not isinstance(experiment.name, str):
-            raise BadRequest("name is required")
+            raise BadRequest(
+                code="MissingRequiredTemplateName", message="name is required"
+            )
 
         stored_experiment = (
             self.session.query(models.Experiment)
@@ -103,7 +105,10 @@ class ExperimentController:
             .first()
         )
         if stored_experiment:
-            raise BadRequest("an experiment with that name already exists")
+            raise BadRequest(
+                code="ExperimentNameExists",
+                message="an experiment with that name already exists",
+            )
 
         if experiment.copy_from:
             experiment = self.copy_experiment(
@@ -185,7 +190,10 @@ class ExperimentController:
             .first()
         )
         if stored_experiment and stored_experiment.uuid != experiment_id:
-            raise BadRequest("an experiment with that name already exists")
+            raise BadRequest(
+                code="InvalidExperimentId",
+                message="an experiment with that name already exists",
+            )
 
         if experiment.template_id:
             return self.update_experiment_from_template(
@@ -281,7 +289,9 @@ class ExperimentController:
         )
 
         if stored_experiment is None:
-            raise BadRequest("source experiment does not exist")
+            raise BadRequest(
+                code="InvalidExperimentId", message="source experiment does not exist"
+            )
 
         experiment = models.Experiment(
             uuid=uuid_alpha(), name=experiment.name, project_id=project_id

--- a/projects/controllers/experiments/runs/datasets.py
+++ b/projects/controllers/experiments/runs/datasets.py
@@ -16,8 +16,16 @@ class DatasetController:
     def __init__(self, session):
         self.session = session
 
-    def get_dataset(self, project_id: str, experiment_id: str, run_id: str, operator_id: str,
-                    page: Optional[int] = 1, page_size: Optional[int] = 10, accept: Optional[str] = None):
+    def get_dataset(
+        self,
+        project_id: str,
+        experiment_id: str,
+        run_id: str,
+        operator_id: str,
+        page: Optional[int] = 1,
+        page_size: Optional[int] = 10,
+        accept: Optional[str] = None,
+    ):
         """
         Get dataset records from a run. Supports pagination.
 
@@ -53,7 +61,10 @@ class DatasetController:
         try:
             metadata = stat_dataset(name=name, operator_id=operator_id, run_id=run_id)
         except FileNotFoundError:
-            raise NotFound("The specified run does not contain dataset")
+            raise NotFound(
+                code="DatasetNotFound",
+                message="The specified run does not contain dataset",
+            )
 
         dataset = load_dataset(
             name=name,
@@ -97,10 +108,12 @@ class DatasetController:
         dataset_name = operator.parameters.get("dataset")
 
         if dataset_name is None:
-            operators = self.session.query(models.Operator) \
-                .filter_by(experiment_id=experiment_id) \
-                .filter(models.Operator.uuid != operator_id) \
+            operators = (
+                self.session.query(models.Operator)
+                .filter_by(experiment_id=experiment_id)
+                .filter(models.Operator.uuid != operator_id)
                 .all()
+            )
 
             for operator in operators:
                 dataset_name = operator.parameters.get("dataset")
@@ -108,6 +121,8 @@ class DatasetController:
                     break
 
             if dataset_name is None:
-                raise NotFound("No dataset assigned to the run")
+                raise NotFound(
+                    code="DatasetNotFound", message="No dataset assigned to the run"
+                )
 
         return dataset_name

--- a/projects/controllers/experiments/runs/metrics.py
+++ b/projects/controllers/experiments/runs/metrics.py
@@ -2,14 +2,16 @@
 """Experiments Metrics controller."""
 import platiagro
 
-from projects.exceptions import NotFound
+from projects.exceptions import InternalServerError
 
 
 class MetricController:
     def __init__(self, session):
         self.session = session
 
-    def list_metrics(self, project_id: str, experiment_id: str, run_id: str, operator_id: str):
+    def list_metrics(
+        self, project_id: str, experiment_id: str, run_id: str, operator_id: str
+    ):
         """
         Lists all metrics from object storage.
 
@@ -27,8 +29,8 @@ class MetricController:
             A list of metrics.
         """
         try:
-            return platiagro.list_metrics(experiment_id=experiment_id,
-                                          operator_id=operator_id,
-                                          run_id=run_id)
-        except FileNotFoundError as e:
-            raise NotFound(str(e))
+            return platiagro.list_metrics(
+                experiment_id=experiment_id, operator_id=operator_id, run_id=run_id
+            )
+        except FileNotFoundError:
+            return []

--- a/projects/controllers/experiments/runs/metrics.py
+++ b/projects/controllers/experiments/runs/metrics.py
@@ -2,8 +2,6 @@
 """Experiments Metrics controller."""
 import platiagro
 
-from projects.exceptions import InternalServerError
-
 
 class MetricController:
     def __init__(self, session):

--- a/projects/controllers/experiments/runs/results.py
+++ b/projects/controllers/experiments/runs/results.py
@@ -29,11 +29,6 @@ class ResultController:
         -------
         io.BytesIO
             Zip file of experiment results.
-
-        Raises
-        ------
-        NotFound
-            The specified operator has no results.
         """
         if run_id == "latest":
             run_id = get_latest_run_id(experiment_id)

--- a/projects/controllers/experiments/runs/results.py
+++ b/projects/controllers/experiments/runs/results.py
@@ -44,20 +44,12 @@ class ResultController:
             objects_path = f"experiments/{experiment_id}/operators/"
         objects = list_objects(objects_path)
 
-        has_results = False
-
         zip_file = io.BytesIO()
-        with zipfile.ZipFile(zip_file, 'a', zipfile.ZIP_DEFLATED) as z:
+        with zipfile.ZipFile(zip_file, "a", zipfile.ZIP_DEFLATED) as z:
             for object in objects:
                 file = self._download_result(object.object_name, run_id)
                 if file is not None:
                     z.writestr(f"{file['operatorId']}/{file['filename']}", file["data"])
-                    has_results = True
-
-        if not has_results:
-            if operator_id:
-                raise NotFound("The specified operator has no results")
-            raise NotFound("The specified run has no results")
 
         zip_file.seek(0)
 
@@ -72,7 +64,9 @@ class ResultController:
             filename = object_name_splitted[2]
             filename_pattern = re.compile(r"figure-([0-9]{18})\.(png|html)")
             if filename_pattern.match(filename):
-                return {"filename": filename,
-                        "data": get_object(object_name),
-                        "operatorId": object_name_splitted[0]}
+                return {
+                    "filename": filename,
+                    "data": get_object(object_name),
+                    "operatorId": object_name_splitted[0],
+                }
         return None

--- a/projects/controllers/experiments/runs/runs.py
+++ b/projects/controllers/experiments/runs/runs.py
@@ -6,7 +6,7 @@ from projects import models, schemas
 from projects.exceptions import NotFound
 from projects.kfp import runs as kfp_runs
 
-NOT_FOUND = NotFound("The specified run does not exist")
+NOT_FOUND = NotFound(code="RunNotFound", message="The specified run does not exist")
 
 
 class RunController:
@@ -27,8 +27,7 @@ class RunController:
         NotFound
         """
         try:
-            kfp_runs.get_run(experiment_id=experiment_id,
-                             run_id=run_id)
+            kfp_runs.get_run(experiment_id=experiment_id, run_id=run_id)
         except (ApiException, ValueError):
             raise NOT_FOUND
 
@@ -76,17 +75,22 @@ class RunController:
         experiment = self.session.query(models.Experiment).get(experiment_id)
 
         if experiment is None:
-            raise NotFound("The specified experiment does not exist")
+            raise NotFound(
+                code="ExperimentNotFound",
+                message="The specified experiment does not exist",
+            )
 
-        run = kfp_runs.start_run(project_id=project_id,
-                                 experiment_id=experiment_id,
-                                 operators=experiment.operators)
+        run = kfp_runs.start_run(
+            project_id=project_id,
+            experiment_id=experiment_id,
+            operators=experiment.operators,
+        )
         run["experimentId"] = experiment_id
 
         update_data = {"status": "Pending", "status_message": None}
-        self.session.query(models.Operator) \
-            .filter_by(experiment_id=experiment_id) \
-            .update(update_data)
+        self.session.query(models.Operator).filter_by(
+            experiment_id=experiment_id
+        ).update(update_data)
         self.session.commit()
 
         return schemas.Run.from_orm(run)
@@ -112,8 +116,7 @@ class RunController:
             When any of project_id, experiment_id, or run_id does not exist.
         """
         try:
-            run = kfp_runs.get_run(experiment_id=experiment_id,
-                                   run_id=run_id)
+            run = kfp_runs.get_run(experiment_id=experiment_id, run_id=run_id)
         except (ApiException, ValueError):
             raise NOT_FOUND
 
@@ -142,14 +145,14 @@ class RunController:
             # Prevents a bug: if a run was deleted before kfp creates
             # resources on the cluster, operators would be stuck in status 'Pending'
             update_data = {"status": "Terminated", "status_message": None}
-            self.session.query(models.Operator) \
-                .filter_by(experiment_id=experiment_id) \
-                .filter(models.Operator.status.in_(["Running", "Pending"])) \
-                .update(update_data, synchronize_session='fetch')
+            self.session.query(models.Operator).filter_by(
+                experiment_id=experiment_id
+            ).filter(models.Operator.status.in_(["Running", "Pending"])).update(
+                update_data, synchronize_session="fetch"
+            )
             self.session.commit()
 
-            run = kfp_runs.terminate_run(experiment_id=experiment_id,
-                                         run_id=run_id)
+            run = kfp_runs.terminate_run(experiment_id=experiment_id, run_id=run_id)
 
         except ApiException:
             raise NOT_FOUND
@@ -177,8 +180,7 @@ class RunController:
             When any of project_id, experiment_id, or run_id does not exist.
         """
         try:
-            run = kfp_runs.retry_run(experiment_id=experiment_id,
-                                     run_id=run_id)
+            run = kfp_runs.retry_run(experiment_id=experiment_id, run_id=run_id)
         except ApiException:
             raise NOT_FOUND
 

--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -8,7 +8,7 @@ from projects import models, schemas
 from projects.controllers.deployments.runs.runs import RunController
 from projects.controllers.tasks import TaskController
 from projects.controllers.utils import uuid_alpha
-from projects.exceptions import NotFound
+from projects.exceptions import BadRequest, NotFound
 from projects.kfp.monitorings import deploy_monitoring, undeploy_monitoring
 
 NOT_FOUND = NotFound(
@@ -101,7 +101,18 @@ class MonitoringController:
         -------
         projects.schemas.monitoring.Monitoring
         """
-        self.task_controller.raise_if_task_does_not_exist(monitoring.task_id)
+        task_exists = (
+            self.session.query(models.Task.uuid)
+            .filter_by(uuid=monitoring.task_id)
+            .scalar()
+            is not None
+        )
+
+        if not task_exists:
+            raise BadRequest(
+                code="InvalidTaskId",
+                message="The specified task does not exist",
+            )
 
         monitoring = models.Monitoring(
             uuid=uuid_alpha(),

--- a/projects/controllers/monitorings/monitorings.py
+++ b/projects/controllers/monitorings/monitorings.py
@@ -11,7 +11,9 @@ from projects.controllers.utils import uuid_alpha
 from projects.exceptions import NotFound
 from projects.kfp.monitorings import deploy_monitoring, undeploy_monitoring
 
-NOT_FOUND = NotFound("The specified monitoring does not exist")
+NOT_FOUND = NotFound(
+    code="MonitoringNotFound", message="The specified monitoring does not exist"
+)
 
 
 class MonitoringController:
@@ -57,7 +59,10 @@ class MonitoringController:
         )
 
         if not exists:
-            raise NotFound("The specified monitoring does not exist")
+            raise NotFound(
+                code="MonitoringNotFound",
+                message="The specified monitoring does not exist",
+            )
 
     def list_monitorings(self, deployment_id: str):
         """

--- a/projects/controllers/operators/operators.py
+++ b/projects/controllers/operators/operators.py
@@ -23,8 +23,12 @@ from kubernetes.client.rest import ApiException
 NOT_FOUND = NotFound(
     code="OperatorNotFound", message="The specified operator does not exist"
 )
-PARAMETERS_EXCEPTION_MSG = "The specified parameters are not valid"
-DEPENDENCIES_EXCEPTION_MSG = "The specified dependencies are not valid."
+INVALID_PARAMETERS = BadRequest(
+    code="InvalidParameters", message="The specified parameters are not valid"
+)
+INVALID_DEPENDENCIES = BadRequest(
+    code="InvalidDependencies", message="The specified dependencies are not valid."
+)
 
 
 class OperatorController:
@@ -104,12 +108,14 @@ class OperatorController:
             When the operator attributes are invalid.
         """
         if not isinstance(operator.task_id, str):
-            raise BadRequest("taskId is required")
+            raise BadRequest(code="MissingRequiredTaskId", message="taskId is required")
 
         try:
             self.task_controller.raise_if_task_does_not_exist(operator.task_id)
         except NotFound as e:
-            raise BadRequest(e.message)
+            raise BadRequest(
+                code="InvalidTaskId", message=f"source task does not exist: {e.message}"
+            )
 
         if operator.dependencies is None:
             operator.dependencies = []
@@ -124,7 +130,8 @@ class OperatorController:
 
         if experiment_id and deployment_id:
             raise BadRequest(
-                "Operator cannot contain an experiment and a deployment simultaneously"
+                code="InvalidOperatorRequestBody",
+                message="Operator cannot contain an experiment and a deployment simultaneously",
             )
 
         if operator.parameters is None:
@@ -295,13 +302,13 @@ class OperatorController:
             When any parameter value is not str, int, float, bool, list, or dict.
         """
         if not isinstance(parameters, dict):
-            raise BadRequest(PARAMETERS_EXCEPTION_MSG)
+            raise INVALID_PARAMETERS
 
         for key, value in parameters.items():
             if value is not None and not isinstance(
                 value, (str, int, float, bool, list, dict)
             ):
-                raise BadRequest(PARAMETERS_EXCEPTION_MSG)
+                raise INVALID_PARAMETERS
 
     def raise_if_dependencies_are_invalid(
         self,
@@ -332,19 +339,19 @@ class OperatorController:
             When dependencies are cyclic.
         """
         if not isinstance(dependencies, list):
-            raise BadRequest(DEPENDENCIES_EXCEPTION_MSG)
+            raise INVALID_DEPENDENCIES
 
         # check if dependencies has duplicates
         if len(dependencies) != len(set(dependencies)):
-            raise BadRequest(DEPENDENCIES_EXCEPTION_MSG)
+            raise INVALID_DEPENDENCIES
 
         for d in dependencies:
             try:
                 self.raise_if_operator_does_not_exist(d)
                 if d == operator_id:
-                    raise BadRequest(DEPENDENCIES_EXCEPTION_MSG)
+                    raise INVALID_DEPENDENCIES
             except NotFound:
-                raise BadRequest(DEPENDENCIES_EXCEPTION_MSG)
+                raise INVALID_DEPENDENCIES
 
         self.raise_if_has_cycles(
             project_id=project_id,
@@ -397,7 +404,9 @@ class OperatorController:
                 )
                 is True
             ):
-                raise BadRequest("Cyclical dependencies.")
+                raise BadRequest(
+                    code="InvalidCyclicalDependencies", message="Cyclical dependencies."
+                )
         return False
 
     def has_cycles_util(

--- a/projects/controllers/operators/operators.py
+++ b/projects/controllers/operators/operators.py
@@ -20,7 +20,9 @@ from kubernetes.watch import Watch
 from kubernetes.client.rest import ApiException
 
 
-NOT_FOUND = NotFound("The specified operator does not exist")
+NOT_FOUND = NotFound(
+    code="OperatorNotFound", message="The specified operator does not exist"
+)
 PARAMETERS_EXCEPTION_MSG = "The specified parameters are not valid"
 DEPENDENCIES_EXCEPTION_MSG = "The specified dependencies are not valid."
 
@@ -42,13 +44,17 @@ class OperatorController:
         ------
         NotFound
         """
-        operator = self.session.query(models.Operator) \
-            .filter_by(uuid=operator_id)
+        operator = self.session.query(models.Operator).filter_by(uuid=operator_id)
 
         if operator.scalar() is None:
             raise NOT_FOUND
 
-    def list_operators(self, project_id: str, experiment_id: Optional[str] = None, deployment_id: Optional[str] = None):
+    def list_operators(
+        self,
+        project_id: str,
+        experiment_id: Optional[str] = None,
+        deployment_id: Optional[str] = None,
+    ):
         """
         Lists all operators under an experiment.
 
@@ -62,18 +68,22 @@ class OperatorController:
         -------
         projects.schemas.ListOperator
         """
-        operators = self.session.query(models.Operator) \
-            .filter_by(experiment_id=experiment_id) \
-            .filter_by(deployment_id=deployment_id) \
+        operators = (
+            self.session.query(models.Operator)
+            .filter_by(experiment_id=experiment_id)
+            .filter_by(deployment_id=deployment_id)
             .all()
+        )
 
         return schemas.OperatorList.from_orm(operators, len(operators))
 
-    def create_operator(self,
-                        operator: schemas.OperatorCreate,
-                        project_id: str,
-                        experiment_id: Optional[str] = None,
-                        deployment_id: Optional[str] = None):
+    def create_operator(
+        self,
+        operator: schemas.OperatorCreate,
+        project_id: str,
+        experiment_id: Optional[str] = None,
+        deployment_id: Optional[str] = None,
+    ):
         """
         Creates a new operator in our database.
 
@@ -105,41 +115,49 @@ class OperatorController:
             operator.dependencies = []
 
         if experiment_id:
-            self.raise_if_dependencies_are_invalid(project_id=project_id,
-                                                   experiment_id=experiment_id,
-                                                   deployment_id=deployment_id,
-                                                   dependencies=operator.dependencies)
+            self.raise_if_dependencies_are_invalid(
+                project_id=project_id,
+                experiment_id=experiment_id,
+                deployment_id=deployment_id,
+                dependencies=operator.dependencies,
+            )
 
         if experiment_id and deployment_id:
-            raise BadRequest("Operator cannot contain an experiment and a deployment simultaneously")
+            raise BadRequest(
+                "Operator cannot contain an experiment and a deployment simultaneously"
+            )
 
         if operator.parameters is None:
             operator.parameters = {}
 
         self.raise_if_parameters_are_invalid(operator.parameters)
 
-        operator = models.Operator(uuid=uuid_alpha(),
-                                   name=operator.name,
-                                   experiment_id=experiment_id,
-                                   deployment_id=deployment_id,
-                                   task_id=operator.task_id,
-                                   dependencies=operator.dependencies,
-                                   status=operator.status,
-                                   parameters=operator.parameters,
-                                   position_x=operator.position_x,
-                                   position_y=operator.position_y)
+        operator = models.Operator(
+            uuid=uuid_alpha(),
+            name=operator.name,
+            experiment_id=experiment_id,
+            deployment_id=deployment_id,
+            task_id=operator.task_id,
+            dependencies=operator.dependencies,
+            status=operator.status,
+            parameters=operator.parameters,
+            position_x=operator.position_x,
+            position_y=operator.position_y,
+        )
         self.session.add(operator)
         self.session.commit()
         self.session.refresh(operator)
 
         return schemas.Operator.from_orm(operator)
 
-    def update_operator(self,
-                        operator: schemas.OperatorUpdate,
-                        project_id: str,
-                        operator_id: str,
-                        experiment_id: Optional[str] = None,
-                        deployment_id: Optional[str] = None,):
+    def update_operator(
+        self,
+        operator: schemas.OperatorUpdate,
+        project_id: str,
+        operator_id: str,
+        experiment_id: Optional[str] = None,
+        deployment_id: Optional[str] = None,
+    ):
         """
         Updates an operator in our database and adjusts the position of others.
 
@@ -168,35 +186,46 @@ class OperatorController:
             raise NOT_FOUND
 
         if operator.dependencies is not None:
-            self.raise_if_dependencies_are_invalid(project_id=project_id,
-                                                   experiment_id=experiment_id,
-                                                   deployment_id=deployment_id,
-                                                   dependencies=operator.dependencies,
-                                                   operator_id=operator_id)
+            self.raise_if_dependencies_are_invalid(
+                project_id=project_id,
+                experiment_id=experiment_id,
+                deployment_id=deployment_id,
+                dependencies=operator.dependencies,
+                operator_id=operator_id,
+            )
 
         update_data = operator.dict(exclude_unset=True)
 
         # when parameters are updated, also updates status
         if operator.parameters is not None:
-            setted_keys = set(key for key, value in operator.parameters.items() if value != "")
-            all_keys = set(p["name"] for p in stored_operator.task.parameters) - {"dataset", "target"}
+            setted_keys = set(
+                key for key, value in operator.parameters.items() if value != ""
+            )
+            all_keys = set(p["name"] for p in stored_operator.task.parameters) - {
+                "dataset",
+                "target",
+            }
             status = "Setted up" if all_keys <= setted_keys else "Unset"
             update_data.update({"status": status})
 
         update_data.update({"updated_at": datetime.utcnow()})
 
-        self.session.query(models.Operator).filter_by(uuid=operator_id).update(update_data)
+        self.session.query(models.Operator).filter_by(uuid=operator_id).update(
+            update_data
+        )
         self.session.commit()
 
         operator = self.session.query(models.Operator).get(operator_id)
 
         return schemas.Operator.from_orm(operator)
 
-    def delete_operator(self,
-                        project_id: str,
-                        operator_id: str,
-                        experiment_id: Optional[str] = None,
-                        deployment_id: Optional[str] = None):
+    def delete_operator(
+        self,
+        project_id: str,
+        operator_id: str,
+        experiment_id: Optional[str] = None,
+        deployment_id: Optional[str] = None,
+    ):
         """
         Delete an operator in our database.
 
@@ -223,11 +252,13 @@ class OperatorController:
 
         # check if other operators contains the operator being deleted
         # in dependencies and remove this operator from dependencies
-        operators = self.session.query(models.Operator) \
-            .filter_by(experiment_id=experiment_id) \
-            .filter_by(deployment_id=deployment_id) \
-            .filter(models.Operator.uuid != operator_id) \
+        operators = (
+            self.session.query(models.Operator)
+            .filter_by(experiment_id=experiment_id)
+            .filter_by(deployment_id=deployment_id)
+            .filter(models.Operator.uuid != operator_id)
             .all()
+        )
         for op in operators:
             if operator_id in op.dependencies:
                 dependencies = op.dependencies.remove(operator_id)
@@ -237,11 +268,13 @@ class OperatorController:
                 op_update = schemas.OperatorUpdate(
                     dependencies=dependencies,
                 )
-                self.update_operator(project_id=project_id,
-                                     experiment_id=experiment_id,
-                                     deployment_id=deployment_id,
-                                     operator_id=op.uuid,
-                                     operator=op_update)
+                self.update_operator(
+                    project_id=project_id,
+                    experiment_id=experiment_id,
+                    deployment_id=deployment_id,
+                    operator_id=op.uuid,
+                    operator=op_update,
+                )
 
         self.session.delete(operator)
         self.session.commit()
@@ -265,15 +298,19 @@ class OperatorController:
             raise BadRequest(PARAMETERS_EXCEPTION_MSG)
 
         for key, value in parameters.items():
-            if value is not None and not isinstance(value, (str, int, float, bool, list, dict)):
+            if value is not None and not isinstance(
+                value, (str, int, float, bool, list, dict)
+            ):
                 raise BadRequest(PARAMETERS_EXCEPTION_MSG)
 
-    def raise_if_dependencies_are_invalid(self,
-                                          project_id: str,
-                                          dependencies: List,
-                                          experiment_id: Optional[str] = None,
-                                          deployment_id: Optional[str] = None,
-                                          operator_id: Optional[str] = None):
+    def raise_if_dependencies_are_invalid(
+        self,
+        project_id: str,
+        dependencies: List,
+        experiment_id: Optional[str] = None,
+        deployment_id: Optional[str] = None,
+        operator_id: Optional[str] = None,
+    ):
         """
         Raises an exception if the specified dependencies are not valid.
         The invalid dependencies are duplicate elements on the dependencies,
@@ -317,12 +354,14 @@ class OperatorController:
             dependencies=dependencies,
         )
 
-    def raise_if_has_cycles(self,
-                            project_id: str,
-                            operator_id: str,
-                            dependencies: List[str],
-                            experiment_id: Optional[str] = None,
-                            deployment_id: Optional[str] = None):
+    def raise_if_has_cycles(
+        self,
+        project_id: str,
+        operator_id: str,
+        dependencies: List[str],
+        experiment_id: Optional[str] = None,
+        deployment_id: Optional[str] = None,
+    ):
         """
         Raises an exception if the dependencies of operators from experiment are cyclical.
 
@@ -339,27 +378,36 @@ class OperatorController:
         BadRequest
             When dependencies are cyclic.
         """
-        operators = self.session.query(models.Operator) \
-            .filter_by(experiment_id=experiment_id) \
-            .filter_by(deployment_id=deployment_id) \
+        operators = (
+            self.session.query(models.Operator)
+            .filter_by(experiment_id=experiment_id)
+            .filter_by(deployment_id=deployment_id)
             .all()
+        )
 
         visited = dict.fromkeys([op.uuid for op in operators], False)
         recursion_stack = dict.fromkeys([op.uuid for op in operators], False)
 
         for op in operators:
             op_uuid = op.uuid
-            if visited[op_uuid] is False \
-               and self.has_cycles_util(op_uuid, visited, recursion_stack, dependencies, operator_id) is True:
+            if (
+                visited[op_uuid] is False
+                and self.has_cycles_util(
+                    op_uuid, visited, recursion_stack, dependencies, operator_id
+                )
+                is True
+            ):
                 raise BadRequest("Cyclical dependencies.")
         return False
 
-    def has_cycles_util(self,
-                        operator_id: str,
-                        visited: Dict[str, bool],
-                        recursion_stack: Dict[str, bool],
-                        new_dependencies: List[str],
-                        new_dependencies_op: str):
+    def has_cycles_util(
+        self,
+        operator_id: str,
+        visited: Dict[str, bool],
+        recursion_stack: Dict[str, bool],
+        new_dependencies: List[str],
+        new_dependencies_op: str,
+    ):
         """
         Check if a run has cycle.
 
@@ -383,21 +431,33 @@ class OperatorController:
         dependencies = operator.dependencies
 
         if operator_id == new_dependencies_op:
-            dependencies = dependencies + list(set(new_dependencies) - set(dependencies))
+            dependencies = dependencies + list(
+                set(new_dependencies) - set(dependencies)
+            )
 
         # Recur for all neighbours
         # if any neighbour is visited and in
         # recursion_stack then graph is cyclic
         for neighbour in dependencies:
-            if ((visited.get(neighbour) is False and
-                 self.has_cycles_util(neighbour, visited, recursion_stack, new_dependencies, new_dependencies_op) is True) or
-                    recursion_stack.get(neighbour) is True):
+            if (
+                visited.get(neighbour) is False
+                and self.has_cycles_util(
+                    neighbour,
+                    visited,
+                    recursion_stack,
+                    new_dependencies,
+                    new_dependencies_op,
+                )
+                is True
+            ) or recursion_stack.get(neighbour) is True:
                 return True
 
         recursion_stack[operator_id] = False
         return False
 
-    def watch_operator(self, deployment_id: Optional[str] = None, experiment_id: Optional[str] = None):
+    def watch_operator(
+        self, deployment_id: Optional[str] = None, experiment_id: Optional[str] = None
+    ):
         GROUP = "argoproj.io"
         VERSION = "v1alpha1"
         PLURAL = "workflows"

--- a/projects/controllers/operators/operators.py
+++ b/projects/controllers/operators/operators.py
@@ -112,10 +112,8 @@ class OperatorController:
 
         try:
             self.task_controller.raise_if_task_does_not_exist(operator.task_id)
-        except NotFound as e:
-            raise BadRequest(
-                code="InvalidTaskId", message=f"source task does not exist: {e.message}"
-            )
+        except NotFound:
+            raise BadRequest(code="InvalidTaskId", message="source task does not exist")
 
         if operator.dependencies is None:
             operator.dependencies = []

--- a/projects/controllers/predictions.py
+++ b/projects/controllers/predictions.py
@@ -60,10 +60,15 @@ class PredictionController:
             except AttributeError:
                 request = parse_file_buffer_to_seldon_request(file=dataset)
             except FileNotFoundError:
-                raise BadRequest("a valid dataset is required")
+                raise BadRequest(
+                    code="InvalidDataset", message="a valid dataset is required"
+                )
 
         else:
-            raise BadRequest("either dataset name or file is required")
+            raise BadRequest(
+                code="MissingRequiredDatasetOrFile",
+                message="either dataset name or file is required",
+            )
 
         prediction_object = self.create_prediction_database_object(
             prediction_id=str(uuid_alpha()),
@@ -170,7 +175,7 @@ class PredictionController:
         prediction_orm_obj = self.session.query(models.Prediction).get(prediction_id)
 
         if not prediction_orm_obj:
-            raise BadRequest(NOT_FOUND)
+            raise NOT_FOUND
 
         predicton_as_schema = schemas.Prediction.from_orm(prediction_orm_obj)
         return predicton_as_schema

--- a/projects/controllers/predictions.py
+++ b/projects/controllers/predictions.py
@@ -16,7 +16,9 @@ from projects.controllers.utils import (
 from projects.exceptions import BadRequest, NotFound
 from projects.kubernetes.seldon import get_seldon_deployment_url
 
-NOT_FOUND = NotFound("The specified prediction does not exist")
+NOT_FOUND = NotFound(
+    code="PredictionNotFound", message="The specified prediction does not exist"
+)
 
 
 class PredictionController:

--- a/projects/controllers/projects.py
+++ b/projects/controllers/projects.py
@@ -11,7 +11,9 @@ from projects.controllers.experiments import ExperimentController
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, NotFound
 
-NOT_FOUND = NotFound("The specified project does not exist")
+NOT_FOUND = NotFound(
+    code="ProjectNotFound", message="The specified project does not exist"
+)
 
 
 class ProjectController:

--- a/projects/controllers/projects.py
+++ b/projects/controllers/projects.py
@@ -108,7 +108,7 @@ class ProjectController:
             assert sort.lower() in ["asc", "desc"]
             assert column in models.Project.__table__.columns.keys()
         except (AssertionError, ValueError):
-            raise BadRequest("Invalid order argument")
+            raise BadRequest(code="InvalidOrderBy", message="Invalid order argument")
 
         if sort.lower() == "asc":
             query = query.order_by(asc(getattr(models.Project, column)))
@@ -145,7 +145,10 @@ class ProjectController:
             .first()
         )
         if store_project:
-            raise BadRequest("a project with that name already exists")
+            raise BadRequest(
+                code="ProjectNameExists",
+                message="a project with that name already exists",
+            )
 
         project = models.Project(
             uuid=uuid_alpha(),
@@ -224,7 +227,10 @@ class ProjectController:
             .first()
         )
         if stored_project and stored_project.uuid != project_id:
-            raise BadRequest("a project with that name already exists")
+            raise BadRequest(
+                code="ProjectNameExists",
+                message="a project with that name already exists",
+            )
 
         update_data = project.dict(exclude_unset=True)
         update_data.update({"updated_at": datetime.utcnow()})
@@ -295,7 +301,9 @@ class ProjectController:
         """
         total_elements = len(project_ids)
         if total_elements < 1:
-            raise BadRequest("inform at least one project")
+            raise BadRequest(
+                code="MissingRequiredProjectId", message="inform at least one project"
+            )
 
         projects = (
             self.session.query(models.Project)

--- a/projects/controllers/tasks/parameters.py
+++ b/projects/controllers/tasks/parameters.py
@@ -28,6 +28,8 @@ class ParameterController:
         """
         task = self.session.query(models.Task).get(task_id)
         if task is None:
-            raise NotFound("The specified task does not exist")
+            raise NotFound(
+                code="TaskNotFound", message="The specified task does not exist"
+            )
 
         return task.parameters

--- a/projects/controllers/tasks/tasks.py
+++ b/projects/controllers/tasks/tasks.py
@@ -70,7 +70,7 @@ TASK_DEFAULT_READINESS_INITIAL_DELAY_SECONDS = int(
 
 EMAIL_MESSAGE_TEMPLATE = pkgutil.get_data("projects", "config/email-template.html")
 
-NOT_FOUND = NotFound("The specified task does not exist")
+NOT_FOUND = NotFound(code="TaskNotFound", message="The specified task does not exist")
 
 
 class TaskController:

--- a/projects/controllers/tasks/tasks.py
+++ b/projects/controllers/tasks/tasks.py
@@ -428,7 +428,9 @@ class TaskController:
             raise NOT_FOUND
 
         if task.operator:
-            raise Forbidden("Task related to an operator")
+            raise Forbidden(
+                code="TaskProtectedFromDeletion", message="Task related to an operator"
+            )
 
         # remove the volume for the task in the notebook server
         self.background_tasks.add_task(

--- a/projects/controllers/templates.py
+++ b/projects/controllers/templates.py
@@ -95,8 +95,8 @@ class TemplateController:
 
             if not exists:
                 raise BadRequest(
-                    code="ExperimentNotFound",
-                    message="The specified experiment does not exist",
+                    code="InvalidExperimentId",
+                    message="source experiment does not exist",
                 )
 
             operators = (
@@ -115,8 +115,8 @@ class TemplateController:
 
             if not exists:
                 raise BadRequest(
-                    code="DeploymentNotFound",
-                    message="The specified deployment does not exist",
+                    code="InvalidDeploymentId",
+                    message="source deployment does not exist",
                 )
 
             operators = (

--- a/projects/controllers/templates.py
+++ b/projects/controllers/templates.py
@@ -7,7 +7,9 @@ from projects import models, schemas
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, NotFound
 
-NOT_FOUND = NotFound("The specified template does not exist")
+NOT_FOUND = NotFound(
+    code="TemplateNotFound", message="The specified template does not exist"
+)
 
 
 class TemplateController:
@@ -27,10 +29,13 @@ class TemplateController:
         ------
         NotFound
         """
-        exists = self.session.query(models.Template.uuid) \
-            .filter_by(uuid=template_id) \
-            .filter_by(tenant=self.kubeflow_userid) \
-            .scalar() is not None
+        exists = (
+            self.session.query(models.Template.uuid)
+            .filter_by(uuid=template_id)
+            .filter_by(tenant=self.kubeflow_userid)
+            .scalar()
+            is not None
+        )
 
         if not exists:
             raise NOT_FOUND
@@ -43,11 +48,17 @@ class TemplateController:
         -------
         projects.schemas.template.TemplateList
         """
-        templates = self.session.query(models.Template) \
-            .filter_by(tenant=self.kubeflow_userid) \
+        templates = (
+            self.session.query(models.Template)
+            .filter_by(tenant=self.kubeflow_userid)
             .all()
+        )
         # sort the list in place, using natural sort
-        templates.sort(key=lambda o: [int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", o.name)])
+        templates.sort(
+            key=lambda o: [
+                int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", o.name)
+            ]
+        )
 
         return schemas.TemplateList.from_orm(templates, len(templates))
 
@@ -73,35 +84,53 @@ class TemplateController:
 
         if template.experiment_id:
 
-            exists = self.session.query(models.Experiment.uuid) \
-                .filter_by(uuid=template.experiment_id) \
-                .scalar() is not None
+            exists = (
+                self.session.query(models.Experiment.uuid)
+                .filter_by(uuid=template.experiment_id)
+                .scalar()
+                is not None
+            )
 
             if not exists:
-                raise BadRequest("The specified experiment does not exist")
+                raise BadRequest(
+                    code="ExperimentNotFound",
+                    message="The specified experiment does not exist",
+                )
 
-            operators = self.session.query(models.Operator) \
-                .filter_by(experiment_id=template.experiment_id) \
+            operators = (
+                self.session.query(models.Operator)
+                .filter_by(experiment_id=template.experiment_id)
                 .all()
+            )
         elif template.deployment_id:
 
-            exists = self.session.query(models.Deployment.uuid) \
-                .filter_by(uuid=template.deployment_id) \
-                .scalar() is not None
+            exists = (
+                self.session.query(models.Deployment.uuid)
+                .filter_by(uuid=template.deployment_id)
+                .scalar()
+                is not None
+            )
 
             if not exists:
-                raise BadRequest("The specified deployment does not exist")
+                raise BadRequest(
+                    code="DeploymentNotFound",
+                    message="The specified deployment does not exist",
+                )
 
-            operators = self.session.query(models.Operator) \
-                .filter_by(deployment_id=template.deployment_id) \
+            operators = (
+                self.session.query(models.Operator)
+                .filter_by(deployment_id=template.deployment_id)
                 .all()
+            )
         else:
             raise BadRequest("experimentId or deploymentId needed to create template.")
 
-        stored_template = self.session.query(models.Template) \
-            .filter_by(name=template.name) \
-            .filter_by(tenant=self.kubeflow_userid) \
+        stored_template = (
+            self.session.query(models.Template)
+            .filter_by(name=template.name)
+            .filter_by(tenant=self.kubeflow_userid)
             .first()
+        )
         if stored_template:
             raise BadRequest("a template with that name already exists")
 
@@ -155,10 +184,12 @@ class TemplateController:
         NotFound
             When template_id does not exist.
         """
-        template = self.session.query(models.Template) \
-            .filter_by(uuid=template_id) \
-            .filter_by(tenant=self.kubeflow_userid) \
+        template = (
+            self.session.query(models.Template)
+            .filter_by(uuid=template_id)
+            .filter_by(tenant=self.kubeflow_userid)
             .first()
+        )
 
         if template is None:
             raise NOT_FOUND
@@ -185,26 +216,29 @@ class TemplateController:
         """
         self.raise_if_template_does_not_exist(template_id)
 
-        stored_template = self.session.query(models.Template) \
-            .filter_by(name=template.name) \
-            .filter_by(tenant=self.kubeflow_userid) \
+        stored_template = (
+            self.session.query(models.Template)
+            .filter_by(name=template.name)
+            .filter_by(tenant=self.kubeflow_userid)
             .first()
+        )
         if stored_template and stored_template.uuid != template_id:
             raise BadRequest("a template with that name already exists")
 
         update_data = template.dict(exclude_unset=True)
         update_data.update({"updated_at": datetime.utcnow()})
 
-        self.session.query(models.Template) \
-            .filter_by(uuid=template_id) \
-            .filter_by(tenant=self.kubeflow_userid) \
-            .update(update_data)
+        self.session.query(models.Template).filter_by(uuid=template_id).filter_by(
+            tenant=self.kubeflow_userid
+        ).update(update_data)
         self.session.commit()
 
-        template = self.session.query(models.Template) \
-            .filter_by(uuid=template_id) \
-            .filter_by(tenant=self.kubeflow_userid) \
+        template = (
+            self.session.query(models.Template)
+            .filter_by(uuid=template_id)
+            .filter_by(tenant=self.kubeflow_userid)
             .first()
+        )
 
         return schemas.Template.from_orm(template)
 
@@ -225,10 +259,12 @@ class TemplateController:
         NotFound
             When template_id does not exist.
         """
-        template = self.session.query(models.Template) \
-            .filter_by(uuid=template_id) \
-            .filter_by(tenant=self.kubeflow_userid) \
+        template = (
+            self.session.query(models.Template)
+            .filter_by(uuid=template_id)
+            .filter_by(tenant=self.kubeflow_userid)
             .first()
+        )
 
         if template is None:
             raise NOT_FOUND
@@ -260,10 +296,12 @@ class TemplateController:
         if total_elements < 1:
             raise BadRequest("inform at least one template")
 
-        templates = self.session.query(models.Template) \
-            .filter(models.Template.uuid.in_(template_ids)) \
-            .filter_by(tenant=self.kubeflow_userid) \
+        templates = (
+            self.session.query(models.Template)
+            .filter(models.Template.uuid.in_(template_ids))
+            .filter_by(tenant=self.kubeflow_userid)
             .all()
+        )
 
         for template in templates:
             self.session.delete(template)

--- a/projects/controllers/templates.py
+++ b/projects/controllers/templates.py
@@ -80,7 +80,9 @@ class TemplateController:
             When the project attributes are invalid.
         """
         if not isinstance(template.name, str):
-            raise BadRequest("name is required")
+            raise BadRequest(
+                code="MissingRequiredTemplateName", message="name is required"
+            )
 
         if template.experiment_id:
 
@@ -123,7 +125,10 @@ class TemplateController:
                 .all()
             )
         else:
-            raise BadRequest("experimentId or deploymentId needed to create template.")
+            raise BadRequest(
+                code="MissingRequiredExperimentIdOrDeploymentId",
+                message="experimentId or deploymentId needed to create template.",
+            )
 
         stored_template = (
             self.session.query(models.Template)
@@ -132,7 +137,10 @@ class TemplateController:
             .first()
         )
         if stored_template:
-            raise BadRequest("a template with that name already exists")
+            raise BadRequest(
+                code="TemplateNameExists",
+                message="a template with that name already exists",
+            )
 
         # order operators by dependencies
         operators_ordered = []
@@ -223,7 +231,10 @@ class TemplateController:
             .first()
         )
         if stored_template and stored_template.uuid != template_id:
-            raise BadRequest("a template with that name already exists")
+            raise BadRequest(
+                code="TemplateNameExists",
+                message="a template with that name already exists",
+            )
 
         update_data = template.dict(exclude_unset=True)
         update_data.update({"updated_at": datetime.utcnow()})
@@ -294,7 +305,9 @@ class TemplateController:
         """
         total_elements = len(template_ids)
         if total_elements < 1:
-            raise BadRequest("inform at least one template")
+            raise BadRequest(
+                code="MissingRequiredTemplateId", message="inform at least one template"
+            )
 
         templates = (
             self.session.query(models.Template)

--- a/projects/exceptions.py
+++ b/projects/exceptions.py
@@ -1,30 +1,83 @@
 # -*- coding: utf-8 -*-
+"""
+Useful exception classes that are used to return HTTP errors.
+"""
 
 
-class BadRequest(Exception):
-    def __init__(self, message: str):
+class ApiException(Exception):
+    """
+    The base exception class for all APIExceptions.
+
+    Parameters
+    ----------
+    code : str
+        Error code.
+    message : str
+        Human readable string describing the exception.
+    status_code : int
+        HTTP status code.
+    """
+
+    def __init__(self, code: str, message: str, status_code: int):
+        self.code = code
         self.message = message
-        self.code = 400
+        self.status_code = status_code
 
 
-class Forbidden(Exception):
-    def __init__(self, message: str):
-        self.message = message
-        self.code = 403
+class BadRequest(ApiException):
+    """
+    Bad Request response status code indicates that the server cannot or will not
+    process the request due to something that is perceived to be a client error.
+
+    A common cause is that the client has sent invalid request values.
+    """
+
+    def __init__(self, code: str, message: str):
+        super().__init__(code, message, status_code=400)
 
 
-class NotFound(Exception):
-    def __init__(self, message: str):
-        self.message = message
-        self.code = 404
+class Forbidden(ApiException):
+    """
+    Forbidden client error status response code indicates that the server understands
+    the request but refuses to authorize it.
+    """
+
+    def __init__(self, code: str, message: str):
+        super().__init__(code, message, status_code=403)
 
 
-class InternalServerError(Exception):
-    def __init__(self, message: str):
-        self.message = message
-        self.code = 500
+class NotFound(ApiException):
+    """
+    Not Found client error response code indicates that the server can't find the requested resource.
 
-class ServiceUnavailable(Exception):
-    def __init__(self, message: str):
-        self.message = message
-        self.code = 503
+    A common cause is that a provided ID does not exist in the database.
+    """
+
+    def __init__(self, code: str, message: str):
+        super().__init__(code, message, status_code=404)
+
+
+class InternalServerError(ApiException):
+    """
+    Internal Server Error server error response code indicates that the server
+    encountered an unexpected condition that prevented it from fulfilling the request.
+
+    This error response is a generic "catch-all" response.
+    You should log error responses like the 500 status code with more details about
+    the request to prevent the error from happening again in the future.
+    """
+
+    def __init__(self, code: str, message: str):
+        super().__init__(code, message, status_code=500)
+
+
+class ServiceUnavailable(ApiException):
+    """
+    Service Unavailable server error response code indicates that the server is
+    not ready to handle the request.
+
+    A common cause is that the database is not available or overloaded.
+    """
+
+    def __init__(self, code: str, message: str):
+        super().__init__(code, message, status_code=503)

--- a/projects/kfp/monitorings.py
+++ b/projects/kfp/monitorings.py
@@ -183,4 +183,7 @@ def undeploy_monitoring(monitoring_id):
             namespace=trigger_custom_object["metadata"]["namespace"],
         )
     except ApiException:
-        raise NotFound("Monitoring resources do not exist.")
+        raise NotFound(
+            code="MonitoringNotFound",
+            message="The specified monitoring does not exist.",
+        )

--- a/projects/kfp/runs.py
+++ b/projects/kfp/runs.py
@@ -132,7 +132,7 @@ def get_run(run_id, experiment_id):
             run_id=run_id,
         )
     except (ApiException, ValueError):
-        raise NotFound("The specified run does not exist")
+        raise NotFound(code="RunNotFound", message="The specified run does not exist")
 
     workflow_manifest = json.loads(kfp_run.pipeline_runtime.workflow_manifest)
 
@@ -231,7 +231,7 @@ def terminate_run(run_id, experiment_id):
             run_id = get_latest_run_id(experiment_id)
         kfp_client().runs.terminate_run(run_id=run_id)
     except (ApiException, ValueError):
-        raise NotFound("The specified run does not exist")
+        raise NotFound(code="RunNotFound", message="The specified run does not exist")
 
     return {"message": "Run terminated"}
 

--- a/projects/kfp/runs.py
+++ b/projects/kfp/runs.py
@@ -265,7 +265,7 @@ def retry_run(run_id, experiment_id):
     if kfp_run.run.status == "Failed":
         kfp_client().runs.retry_run(run_id=kfp_run.run.id)
     else:
-        raise BadRequest("Not a failed run")
+        raise BadRequest(code="InvalidRunId", message="Not a failed run")
 
     return {"message": "Run re-initiated successfully"}
 

--- a/projects/kubernetes/kube_config.py
+++ b/projects/kubernetes/kube_config.py
@@ -30,4 +30,6 @@ def load_kube_config():
     try:
         config.load_incluster_config()
     except Exception:
-        raise InternalServerError("Failed to connect to cluster.")
+        raise InternalServerError(
+            code="CannotConnectToCluster", message="Failed to connect to cluster."
+        )

--- a/projects/kubernetes/notebook.py
+++ b/projects/kubernetes/notebook.py
@@ -113,7 +113,8 @@ def create_persistent_volume_claim(name, mount_path):
         body = literal_eval(e.body)
         message = body["message"]
         raise InternalServerError(
-            f"Error while trying to create persistent volume claim: {message}"
+            code="CannotCreatePersistentVolumeClaim",
+            message=f"Error while trying to create persistent volume claim: {message}",
         )
 
     try:
@@ -146,7 +147,8 @@ def create_persistent_volume_claim(name, mount_path):
         body = literal_eval(e.body)
         message = body["message"]
         raise InternalServerError(
-            f"Error while trying to patch notebook server: {message}"
+            code="CannotPatchNotebookServer",
+            message=f"Error while trying to patch notebook server: {message}",
         )
 
     try:
@@ -211,7 +213,8 @@ def create_persistent_volume_claim(name, mount_path):
         body = literal_eval(e.body)
         message = body["message"]
         raise InternalServerError(
-            f"Error while trying to patch notebook server: {message}"
+            code="CannotPatchNotebookServer",
+            message=f"Error while trying to patch notebook server: {message}",
         )
 
 
@@ -246,7 +249,8 @@ def update_persistent_volume_claim(name, mount_path):
         body = literal_eval(e.body)
         message = body["message"]
         raise InternalServerError(
-            f"Error while trying to patch notebook server: {message}"
+            code="CannotPatchNotebookServer",
+            message=f"Error while trying to patch notebook server: {message}",
         )
 
     try:
@@ -307,7 +311,8 @@ def update_persistent_volume_claim(name, mount_path):
         body = literal_eval(e.body)
         message = body["message"]
         raise InternalServerError(
-            f"Error while trying to patch notebook server: {message}"
+            code="CannotPatchNotebookServer",
+            message=f"Error while trying to patch notebook server: {message}",
         )
 
 
@@ -341,7 +346,8 @@ def remove_persistent_volume_claim(name, mount_path):
         body = literal_eval(e.body)
         message = body["message"]
         raise InternalServerError(
-            f"Error while trying to patch notebook server: {message}"
+            code="CannotPatchNotebookServer",
+            message=f"Error while trying to patch notebook server: {message}",
         )
 
     try:
@@ -401,7 +407,8 @@ def remove_persistent_volume_claim(name, mount_path):
         body = literal_eval(e.body)
         message = body["message"]
         raise InternalServerError(
-            f"Error while trying to patch notebook server: {message}"
+            code="CannotPatchNotebookServer",
+            message=f"Error while trying to patch notebook server: {message}",
         )
 
 

--- a/projects/models/deployment.py
+++ b/projects/models/deployment.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
 from projects.database import Base
-from projects.exceptions import NotFound
 from projects.models.monitoring import Monitoring
 from projects.models.operator import Operator
 

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -37,7 +37,11 @@ class TestComparisons(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}/comparisons")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -65,7 +69,11 @@ class TestComparisons(unittest.TestCase):
             json={},
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -107,7 +115,11 @@ class TestComparisons(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -123,7 +135,11 @@ class TestComparisons(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified comparison does not exist"}
+        expected = {
+            "message": "The specified comparison does not exist",
+            "code": "ComparisonNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -169,7 +185,11 @@ class TestComparisons(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/projects/{project_id}/comparisons/{comparison_id}")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -183,7 +203,11 @@ class TestComparisons(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/projects/{project_id}/comparisons/{comparison_id}")
         result = rv.json()
 
-        expected = {"message": "The specified comparison does not exist"}
+        expected = {
+            "message": "The specified comparison does not exist",
+            "code": "ComparisonNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -40,7 +40,6 @@ class TestComparisons(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -72,7 +71,6 @@ class TestComparisons(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -118,7 +116,6 @@ class TestComparisons(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -138,7 +135,6 @@ class TestComparisons(unittest.TestCase):
         expected = {
             "message": "The specified comparison does not exist",
             "code": "ComparisonNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -188,7 +184,6 @@ class TestComparisons(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -206,7 +201,6 @@ class TestComparisons(unittest.TestCase):
         expected = {
             "message": "The specified comparison does not exist",
             "code": "ComparisonNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -36,7 +36,11 @@ class TestExperimentData(unittest.TestCase):
 
         rv = TEST_CLIENT.get(f"/projects/unk/experiments/{experiment_id}/data")
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -48,7 +52,11 @@ class TestExperimentData(unittest.TestCase):
 
         rv = TEST_CLIENT.get(f"/projects/{project_id}/experiments/unk/data")
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -39,7 +39,6 @@ class TestExperimentData(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -55,7 +54,6 @@ class TestExperimentData(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -42,7 +42,11 @@ class TestDatasets(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -60,7 +64,11 @@ class TestDatasets(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -78,7 +86,11 @@ class TestDatasets(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified operator does not exist"}
+        expected = {
+            "message": "The specified operator does not exist",
+            "code": "OperatorNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -105,12 +117,18 @@ class TestDatasets(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified run does not contain dataset"}
+        expected = {
+            "message": "The specified run does not contain dataset",
+            "code": "DatasetNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
         mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_stat_dataset.assert_any_call(name=name, operator_id=operator_id, run_id=run_id)
+        mock_stat_dataset.assert_any_call(
+            name=name, operator_id=operator_id, run_id=run_id
+        )
 
     @mock.patch(
         "kfp.Client",
@@ -147,28 +165,34 @@ class TestDatasets(unittest.TestCase):
         result = rv.json()
 
         expected = {
-            'columns': [
-                'SepalLengthCm',
-                'SepalWidthCm',
-                'PetalLengthCm',
-                'PetalWidthCm',
-                'Species'],
-            'data': [
-                [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'],
-                [4.9, 3.0, 1.4, 0.2, 'Iris-setosa'],
-                [4.7, 3.2, 1.3, 0.2, 'Iris-setosa'],
-                [4.6, 3.1, 1.5, 0.2, 'Iris-setosa']],
-            'total': 4
+            "columns": [
+                "SepalLengthCm",
+                "SepalWidthCm",
+                "PetalLengthCm",
+                "PetalWidthCm",
+                "Species",
+            ],
+            "data": [
+                [5.1, 3.5, 1.4, 0.2, "Iris-setosa"],
+                [4.9, 3.0, 1.4, 0.2, "Iris-setosa"],
+                [4.7, 3.2, 1.3, 0.2, "Iris-setosa"],
+                [4.6, 3.1, 1.5, 0.2, "Iris-setosa"],
+            ],
+            "total": 4,
         }
 
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 200)
 
         mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_stat_dataset.assert_any_call(name=name, operator_id=operator_id, run_id='4546465')
-        mock_load_dataset.assert_any_call(name=name, run_id='4546465', operator_id=operator_id, page=1, page_size=10)
+        mock_stat_dataset.assert_any_call(
+            name=name, operator_id=operator_id, run_id="4546465"
+        )
+        mock_load_dataset.assert_any_call(
+            name=name, run_id="4546465", operator_id=operator_id, page=1, page_size=10
+        )
 
-    @ mock.patch(
+    @mock.patch(
         "kfp.Client",
         return_value=util.MOCK_KFP_CLIENT,
     )
@@ -176,7 +200,9 @@ class TestDatasets(unittest.TestCase):
         "projects.controllers.experiments.runs.datasets.stat_dataset",
         side_effect=util.FILE_NOT_FOUND_ERROR,
     )
-    def test_list_datasets_no_dataset_assigned_to_run(self, mock_stat_dataset, mock_kfp_client):
+    def test_list_datasets_no_dataset_assigned_to_run(
+        self, mock_stat_dataset, mock_kfp_client
+    ):
         """
         Should return an http status 404 and a message 'No dataset assigned to the run'.
         """
@@ -190,12 +216,18 @@ class TestDatasets(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/datasets"
         )
         result = rv.json()
-        expected = {"message": "The specified run does not contain dataset"}
+        expected = {
+            "message": "The specified run does not contain dataset",
+            "code": "DatasetNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
         mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_stat_dataset.assert_any_call(name=name, operator_id=operator_id, run_id='4546465')
+        mock_stat_dataset.assert_any_call(
+            name=name, operator_id=operator_id, run_id="4546465"
+        )
 
     @mock.patch(
         "kfp.Client",
@@ -212,9 +244,11 @@ class TestDatasets(unittest.TestCase):
     )
     @mock.patch(
         "projects.controllers.experiments.runs.datasets.load_dataset",
-        side_effect=util.mock_load_dataset
+        side_effect=util.mock_load_dataset,
     )
-    def test_list_datasets_page_size_1(self, mock_load_dataset, mock_stat_dataset, mock_kfp_client):
+    def test_list_datasets_page_size_1(
+        self, mock_load_dataset, mock_stat_dataset, mock_kfp_client
+    ):
         """
         Should return a list of data and columns with one element.
         """
@@ -230,16 +264,27 @@ class TestDatasets(unittest.TestCase):
         result = rv.json()
 
         expected = {
-            "columns": ["col0", "col1", "col2", "col3", "col4", ],
-            "data": [[5.1, 3.5, 1.4, 0.2, "Iris-setosa"],
-                     ],
+            "columns": [
+                "col0",
+                "col1",
+                "col2",
+                "col3",
+                "col4",
+            ],
+            "data": [
+                [5.1, 3.5, 1.4, 0.2, "Iris-setosa"],
+            ],
             "total": 4,
         }
         self.assertDictEqual(expected, result)
 
         mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_stat_dataset.assert_any_call(name=name, operator_id=operator_id, run_id='4546465')
-        mock_load_dataset.assert_any_call(name=name, run_id='4546465', operator_id=operator_id, page=1, page_size=1)
+        mock_stat_dataset.assert_any_call(
+            name=name, operator_id=operator_id, run_id="4546465"
+        )
+        mock_load_dataset.assert_any_call(
+            name=name, run_id="4546465", operator_id=operator_id, page=1, page_size=1
+        )
 
     @mock.patch(
         "kfp.Client",
@@ -255,9 +300,11 @@ class TestDatasets(unittest.TestCase):
     )
     @mock.patch(
         "projects.controllers.experiments.runs.datasets.load_dataset",
-        side_effect=util.mock_load_dataset
+        side_effect=util.mock_load_dataset,
     )
-    def test_list_datasets_page_size_minus_1(self, mock_load_dataset, mock_stat_dataset, mock_kfp_client):
+    def test_list_datasets_page_size_minus_1(
+        self, mock_load_dataset, mock_stat_dataset, mock_kfp_client
+    ):
         """
         Should return the dataset formatted as a .CSV file with one less page.
         """
@@ -273,23 +320,29 @@ class TestDatasets(unittest.TestCase):
         result = rv.json()
         expected = {
             "columns": ["col0", "col1", "col2", "col3", "col4"],
-            "data": [[5.1, 3.5, 1.4, 0.2, "Iris-setosa"],
-                     [4.9, 3.0, 1.4, 0.2, 'Iris-setosa'],
-                     [4.7, 3.2, 1.3, 0.2, 'Iris-setosa']],
+            "data": [
+                [5.1, 3.5, 1.4, 0.2, "Iris-setosa"],
+                [4.9, 3.0, 1.4, 0.2, "Iris-setosa"],
+                [4.7, 3.2, 1.3, 0.2, "Iris-setosa"],
+            ],
             "total": 3,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 200)
 
         mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_stat_dataset.assert_any_call(name=name, operator_id=operator_id, run_id='4546465')
-        mock_load_dataset.assert_any_call(name=name, run_id='4546465', operator_id=operator_id, page=1, page_size=-1)
+        mock_stat_dataset.assert_any_call(
+            name=name, operator_id=operator_id, run_id="4546465"
+        )
+        mock_load_dataset.assert_any_call(
+            name=name, run_id="4546465", operator_id=operator_id, page=1, page_size=-1
+        )
 
-    @ mock.patch(
+    @mock.patch(
         "kfp.Client",
         return_value=util.MOCK_KFP_CLIENT,
     )
-    @ mock.patch(
+    @mock.patch(
         "projects.controllers.experiments.runs.datasets.stat_dataset",
         return_value={
             "columns": util.IRIS_HEADERLESS_COLUMNS,
@@ -299,9 +352,11 @@ class TestDatasets(unittest.TestCase):
     )
     @mock.patch(
         "projects.controllers.experiments.runs.datasets.load_dataset",
-        side_effect=util.mock_load_dataset
+        side_effect=util.mock_load_dataset,
     )
-    def test_list_datasets_page_not_exist(self, mock_load_dataset, mock_stat_dataset, mock_kfp_client):
+    def test_list_datasets_page_not_exist(
+        self, mock_load_dataset, mock_stat_dataset, mock_kfp_client
+    ):
         """
         Should return the dataset formatted as a .CSV file with three pages.
         """
@@ -317,14 +372,20 @@ class TestDatasets(unittest.TestCase):
         result = rv.json()
         expected = {
             "columns": ["col0", "col1", "col2", "col3", "col4"],
-            "data": [[5.1, 3.5, 1.4, 0.2, "Iris-setosa"],
-                     [4.9, 3.0, 1.4, 0.2, 'Iris-setosa'],
-                     [4.7, 3.2, 1.3, 0.2, 'Iris-setosa']],
+            "data": [
+                [5.1, 3.5, 1.4, 0.2, "Iris-setosa"],
+                [4.9, 3.0, 1.4, 0.2, "Iris-setosa"],
+                [4.7, 3.2, 1.3, 0.2, "Iris-setosa"],
+            ],
             "total": 3,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 200)
 
         mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_stat_dataset.assert_any_call(name=name, operator_id=operator_id, run_id='4546465')
-        mock_load_dataset.assert_any_call(name=name, run_id='4546465', operator_id=operator_id, page=2, page_size=3)
+        mock_stat_dataset.assert_any_call(
+            name=name, operator_id=operator_id, run_id="4546465"
+        )
+        mock_load_dataset.assert_any_call(
+            name=name, run_id="4546465", operator_id=operator_id, page=2, page_size=3
+        )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -45,7 +45,6 @@ class TestDatasets(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -67,7 +66,6 @@ class TestDatasets(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -89,7 +87,6 @@ class TestDatasets(unittest.TestCase):
         expected = {
             "message": "The specified operator does not exist",
             "code": "OperatorNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -120,7 +117,6 @@ class TestDatasets(unittest.TestCase):
         expected = {
             "message": "The specified run does not contain dataset",
             "code": "DatasetNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -219,7 +215,6 @@ class TestDatasets(unittest.TestCase):
         expected = {
             "message": "The specified run does not contain dataset",
             "code": "DatasetNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -40,7 +40,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -75,7 +74,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -92,7 +90,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "either experiments, templateId or copyFrom is required",
             "code": "MissingRequiredExperimentsOrTemplateIdOrCopyFrom",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -114,7 +111,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "Necessary at least one operator.",
             "code": "MissingRequiredOperatorId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -136,7 +132,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "some experiments do not exist",
             "code": "InvalidExperiments",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -157,7 +152,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "name is required to duplicate deployment",
             "code": "MissingRequiredDeploymentName",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -179,7 +173,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "a deployment with that name already exists",
             "code": "DeploymentNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -414,7 +407,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "source deployment does not exist",
             "code": "InvalidDeploymentId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -504,7 +496,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -522,7 +513,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -556,7 +546,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -576,7 +565,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -598,7 +586,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "a deployment with that name already exists",
             "code": "DeploymentNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -649,7 +636,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -667,7 +653,6 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -39,7 +39,11 @@ class TestDeployments(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}/deployments")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -70,7 +74,11 @@ class TestDeployments(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -83,7 +91,11 @@ class TestDeployments(unittest.TestCase):
         rv = TEST_CLIENT.post(f"/projects/{project_id}/deployments", json={})
         result = rv.json()
 
-        expected = {"message": "either experiments, templateId or copyFrom is required"}
+        expected = {
+            "message": "either experiments, templateId or copyFrom is required",
+            "code": "MissingRequiredExperimentsOrTemplateIdOrCopyFrom",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -101,7 +113,11 @@ class TestDeployments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "Necessary at least one operator."}
+        expected = {
+            "message": "Necessary at least one operator.",
+            "code": "MissingRequiredOperatorId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -333,7 +349,11 @@ class TestDeployments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "source deployment does not exist"}
+        expected = {
+            "message": "source deployment does not exist",
+            "code": "InvalidDeploymentId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -347,7 +367,11 @@ class TestDeployments(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}/deployments/{deployment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -361,7 +385,11 @@ class TestDeployments(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}/deployments/{deployment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -391,7 +419,11 @@ class TestDeployments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -407,7 +439,11 @@ class TestDeployments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -425,7 +461,11 @@ class TestDeployments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "a deployment with that name already exists"}
+        expected = {
+            "message": "a deployment with that name already exists",
+            "code": "DeploymentNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -472,7 +512,11 @@ class TestDeployments(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/projects/{project_id}/deployments/{deployment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -486,7 +530,11 @@ class TestDeployments(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/projects/{project_id}/deployments/{deployment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -3,11 +3,9 @@ import unittest
 import unittest.mock as mock
 
 from fastapi.testclient import TestClient
-from kfp_server_api.exceptions import ApiException
 
 from projects.api.main import app
 from projects.database import session_scope
-from projects.kfp import KF_PIPELINES_NAMESPACE
 
 import tests.util as util
 
@@ -116,6 +114,71 @@ class TestDeployments(unittest.TestCase):
         expected = {
             "message": "Necessary at least one operator.",
             "code": "MissingRequiredOperatorId",
+            "status_code": 400,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_create_deployment_experiments_not_exist_error(self):
+        """
+        Should return a http error 400 and a message 'some experiments do not exist'.
+        """
+        project_id = util.MOCK_UUID_1
+        deployment_name = "deployment-3"
+        experiments = ["unk"]
+
+        rv = TEST_CLIENT.post(
+            f"/projects/{project_id}/deployments",
+            json={"name": deployment_name, "experiments": experiments},
+        )
+        result = rv.json()
+
+        expected = {
+            "message": "some experiments do not exist",
+            "code": "InvalidExperiments",
+            "status_code": 400,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_create_deployment_name_is_required_error(self):
+        """
+        Should return a http error 400 and a message 'name is required to duplicate deployment'.
+        """
+        project_id = util.MOCK_UUID_1
+        copy_from = util.MOCK_UUID_1
+
+        rv = TEST_CLIENT.post(
+            f"/projects/{project_id}/deployments",
+            json={"copyFrom": copy_from},
+        )
+        result = rv.json()
+
+        expected = {
+            "message": "name is required to duplicate deployment",
+            "code": "MissingRequiredDeploymentName",
+            "status_code": 400,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_create_deployment_name_exists_error(self):
+        """
+        Should return a http error 400 and a message 'name is required to duplicate deployment'.
+        """
+        project_id = util.MOCK_UUID_1
+        name = util.MOCK_DEPLOYMENT_NAME_1
+        copy_from = util.MOCK_UUID_1
+
+        rv = TEST_CLIENT.post(
+            f"/projects/{project_id}/deployments",
+            json={"name": name, "copyFrom": copy_from},
+        )
+        result = rv.json()
+
+        expected = {
+            "message": "a deployment with that name already exists",
+            "code": "DeploymentNameExists",
             "status_code": 400,
         }
         self.assertDictEqual(expected, result)
@@ -235,7 +298,6 @@ class TestDeployments(unittest.TestCase):
         mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
         mock_load_config.assert_any_call()
 
-    # @mock.patch("projects.kubernetes.kube_config.config.load_incluster_config")
     @mock.patch(
         "kubernetes.client.CustomObjectsApi",
         return_value=util.MOCK_CUSTOM_OBJECTS_API,
@@ -356,6 +418,78 @@ class TestDeployments(unittest.TestCase):
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
+
+    @mock.patch(
+        "kubernetes.client.CoreV1Api",
+        return_value=util.MOCK_CORE_V1_API,
+    )
+    @mock.patch(
+        "kfp.Client",
+        return_value=util.MOCK_KFP_CLIENT,
+    )
+    @mock.patch(
+        "kubernetes.config.load_kube_config",
+    )
+    def test_create_deployment_with_template_id_success(
+        self,
+        mock_load_config,
+        mock_kfp_client,
+        mock_core_v1_api,
+    ):
+        """
+        Should create and return an deployment successfully.
+        """
+        project_id = util.MOCK_UUID_1
+        template_id = util.MOCK_UUID_2
+
+        rv = TEST_CLIENT.post(
+            f"/projects/{project_id}/deployments",
+            json={"templateId": template_id},
+        )
+        result = rv.json()
+
+        expected = {
+            "deployments": [
+                {
+                    "createdAt": mock.ANY,
+                    "isActive": True,
+                    "deployedAt": None,
+                    "experimentId": None,
+                    "name": util.MOCK_TEMPLATE_NAME_2,
+                    "projectId": project_id,
+                    "position": -1,
+                    "operators": [
+                        {
+                            "createdAt": mock.ANY,
+                            "dependencies": [],
+                            "deploymentId": mock.ANY,
+                            "experimentId": None,
+                            "name": util.MOCK_TASK_NAME_1,
+                            "parameters": {},
+                            "positionX": 0,
+                            "positionY": 0,
+                            "status": "Setted up",
+                            "statusMessage": None,
+                            "task": {"name": "task-1", "parameters": [], "tags": []},
+                            "taskId": util.MOCK_UUID_1,
+                            "updatedAt": mock.ANY,
+                            "uuid": mock.ANY,
+                        },
+                    ],
+                    "status": "Pending",
+                    "updatedAt": mock.ANY,
+                    "uuid": mock.ANY,
+                    "url": None,
+                }
+            ],
+            "total": 1,
+        }
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 200)
+
+        mock_core_v1_api.assert_any_call()
+        mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
+        mock_load_config.assert_any_call()
 
     def test_get_deployment_project_not_found(self):
         """

--- a/tests/test_deployments_runs.py
+++ b/tests/test_deployments_runs.py
@@ -59,7 +59,6 @@ class TestDeploymentsRuns(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertIsInstance(result, dict)
         self.assertEqual(rv.status_code, 404)
@@ -76,7 +75,6 @@ class TestDeploymentsRuns(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertIsInstance(result, dict)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_deployments_runs.py
+++ b/tests/test_deployments_runs.py
@@ -56,7 +56,11 @@ class TestDeploymentsRuns(unittest.TestCase):
             f"/projects/foo/deployments/{deployment_id}/runs", json={}
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertIsInstance(result, dict)
         self.assertEqual(rv.status_code, 404)
         self.assertDictEqual(result, expected)
@@ -69,7 +73,11 @@ class TestDeploymentsRuns(unittest.TestCase):
 
         rv = TEST_CLIENT.post(f"/projects/{project_id}/deployments/foo/runs", json={})
         result = rv.json()
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertIsInstance(result, dict)
         self.assertEqual(rv.status_code, 404)
         self.assertDictEqual(result, expected)

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -40,7 +40,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -75,7 +74,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -107,7 +105,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "an experiment with that name already exists",
             "code": "ExperimentNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -225,7 +222,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "source experiment does not exist",
             "code": "InvalidExperimentId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -243,7 +239,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -261,7 +256,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -304,7 +298,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -324,7 +317,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -346,7 +338,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "an experiment with that name already exists",
             "code": "ExperimentNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -370,7 +361,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified template does not exist",
             "code": "InvalidTemplateId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -434,7 +424,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -452,7 +441,6 @@ class TestExperiments(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -37,7 +37,11 @@ class TestExperiments(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}/experiments")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -68,7 +72,11 @@ class TestExperiments(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -96,7 +104,11 @@ class TestExperiments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "an experiment with that name already exists"}
+        expected = {
+            "message": "an experiment with that name already exists",
+            "code": "ExperimentNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -210,7 +222,11 @@ class TestExperiments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "source experiment does not exist"}
+        expected = {
+            "message": "source experiment does not exist",
+            "code": "InvalidExperimentId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -224,7 +240,11 @@ class TestExperiments(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}/experiments/{experiment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -238,7 +258,11 @@ class TestExperiments(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}/experiments/{experiment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -277,7 +301,11 @@ class TestExperiments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -293,7 +321,11 @@ class TestExperiments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -311,7 +343,11 @@ class TestExperiments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "an experiment with that name already exists"}
+        expected = {
+            "message": "an experiment with that name already exists",
+            "code": "ExperimentNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -331,7 +367,11 @@ class TestExperiments(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified template does not exist"}
+        expected = {
+            "message": "The specified template does not exist",
+            "code": "InvalidTemplateId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -391,7 +431,11 @@ class TestExperiments(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/projects/{project_id}/experiments/{experiment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -405,7 +449,11 @@ class TestExperiments(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/projects/{project_id}/experiments/{experiment_id}")
         result = rv.json()
 
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_experiments_runs.py
+++ b/tests/test_experiments_runs.py
@@ -97,7 +97,6 @@ class TestExperimentsRuns(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -142,7 +141,6 @@ class TestExperimentsRuns(unittest.TestCase):
         expected = {
             "message": "The specified run does not exist",
             "code": "RunNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_experiments_runs.py
+++ b/tests/test_experiments_runs.py
@@ -94,7 +94,11 @@ class TestExperimentsRuns(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}"
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -135,7 +139,11 @@ class TestExperimentsRuns(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/unk"
         )
         result = rv.json()
-        expected = {"message": "The specified run does not exist"}
+        expected = {
+            "message": "The specified run does not exist",
+            "code": "RunNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -41,7 +41,11 @@ class TestFigures(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/figures"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -58,7 +62,11 @@ class TestFigures(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/figures"
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_figures.py
+++ b/tests/test_figures.py
@@ -44,7 +44,6 @@ class TestFigures(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -65,7 +64,6 @@ class TestFigures(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -41,7 +41,11 @@ class TestMetrics(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/metrics"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -58,7 +62,11 @@ class TestMetrics(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/metrics"
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -44,7 +44,6 @@ class TestMetrics(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -65,7 +64,6 @@ class TestMetrics(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -76,9 +76,42 @@ class TestMetrics(unittest.TestCase):
     )
     @mock.patch(
         "platiagro.list_metrics",
+        side_effect=FileNotFoundError(),
+    )
+    def test_list_metrics_success_1(
+        self,
+        mock_list_metrics,
+        mock_kfp_client,
+    ):
+        """
+        Should return a list of metrics successfully.
+        """
+        project_id = util.MOCK_UUID_1
+        experiment_id = util.MOCK_UUID_1
+        run_id = "latest"
+        operator_id = util.MOCK_UUID_1
+
+        rv = TEST_CLIENT.get(
+            f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/metrics"
+        )
+        result = rv.json()
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, [])
+
+        mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
+        mock_list_metrics.assert_any_call(
+            experiment_id=experiment_id, operator_id=operator_id, run_id=run_id
+        )
+
+    @mock.patch(
+        "kfp.Client",
+        return_value=util.MOCK_KFP_CLIENT,
+    )
+    @mock.patch(
+        "platiagro.list_metrics",
         return_value=[{"accuracy": 1.0}],
     )
-    def test_list_metrics_success(
+    def test_list_metrics_success_2(
         self,
         mock_list_metrics,
         mock_kfp_client,

--- a/tests/test_monitoring_figures.py
+++ b/tests/test_monitoring_figures.py
@@ -43,7 +43,6 @@ class TestMonitoringFigures(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -63,7 +62,6 @@ class TestMonitoringFigures(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -83,7 +81,6 @@ class TestMonitoringFigures(unittest.TestCase):
         expected = {
             "message": "The specified monitoring does not exist",
             "code": "MonitoringNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_monitoring_figures.py
+++ b/tests/test_monitoring_figures.py
@@ -40,7 +40,11 @@ class TestMonitoringFigures(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings/{monitoring_id}/figures"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -56,7 +60,11 @@ class TestMonitoringFigures(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings/{monitoring_id}/figures"
         )
         result = rv.json()
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -72,7 +80,11 @@ class TestMonitoringFigures(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings/{monitoring_id}/figures"
         )
         result = rv.json()
-        expected = {"message": "The specified monitoring does not exist"}
+        expected = {
+            "message": "The specified monitoring does not exist",
+            "code": "MonitoringNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_monitorings.py
+++ b/tests/test_monitorings.py
@@ -42,7 +42,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -61,7 +60,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -99,7 +97,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -122,7 +119,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -145,7 +141,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified task does not exist",
             "code": "InvalidTaskId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -199,7 +194,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -219,7 +213,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -239,7 +232,6 @@ class TestMonitorings(unittest.TestCase):
         expected = {
             "message": "The specified monitoring does not exist",
             "code": "MonitoringNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_monitorings.py
+++ b/tests/test_monitorings.py
@@ -39,7 +39,11 @@ class TestMonitorings(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -54,7 +58,11 @@ class TestMonitorings(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings"
         )
         result = rv.json()
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -88,7 +96,11 @@ class TestMonitorings(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -107,7 +119,11 @@ class TestMonitorings(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -126,9 +142,13 @@ class TestMonitorings(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified task does not exist"}
+        expected = {
+            "message": "The specified task does not exist",
+            "code": "InvalidTaskId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
-        self.assertEqual(rv.status_code, 404)
+        self.assertEqual(rv.status_code, 400)
 
     @mock.patch(
         "kfp.Client",
@@ -176,7 +196,11 @@ class TestMonitorings(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings/{monitoring_id}"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -192,7 +216,11 @@ class TestMonitorings(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings/{monitoring_id}"
         )
         result = rv.json()
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -208,7 +236,11 @@ class TestMonitorings(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/monitorings/{monitoring_id}"
         )
         result = rv.json()
-        expected = {"message": "The specified monitoring does not exist"}
+        expected = {
+            "message": "The specified monitoring does not exist",
+            "code": "MonitoringNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_operator_parameters.py
+++ b/tests/test_operator_parameters.py
@@ -42,7 +42,11 @@ class TestOperatorParameters(unittest.TestCase):
             json={},
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -60,7 +64,11 @@ class TestOperatorParameters(unittest.TestCase):
             json={},
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -78,7 +86,11 @@ class TestOperatorParameters(unittest.TestCase):
             json={},
         )
         result = rv.json()
-        expected = {"message": "The specified operator does not exist"}
+        expected = {
+            "message": "The specified operator does not exist",
+            "code": "OperatorNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_operator_parameters.py
+++ b/tests/test_operator_parameters.py
@@ -45,7 +45,6 @@ class TestOperatorParameters(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -67,7 +66,6 @@ class TestOperatorParameters(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -89,7 +87,6 @@ class TestOperatorParameters(unittest.TestCase):
         expected = {
             "message": "The specified operator does not exist",
             "code": "OperatorNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -39,7 +39,11 @@ class TestOperators(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/operators"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -54,7 +58,11 @@ class TestOperators(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/operators"
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -90,7 +98,11 @@ class TestOperators(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -111,7 +123,11 @@ class TestOperators(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -144,7 +160,11 @@ class TestOperators(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified task does not exist"}
+        expected = {
+            "message": "source task does not exist",
+            "code": "InvalidTaskId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -374,7 +394,11 @@ class TestOperators(unittest.TestCase):
             json={},
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -391,7 +415,11 @@ class TestOperators(unittest.TestCase):
             json={},
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -408,7 +436,11 @@ class TestOperators(unittest.TestCase):
             json={},
         )
         result = rv.json()
-        expected = {"message": "The specified operator does not exist"}
+        expected = {
+            "message": "The specified operator does not exist",
+            "code": "OperatorNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -428,7 +460,11 @@ class TestOperators(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified dependencies are not valid."}
+        expected = {
+            "message": "The specified dependencies are not valid.",
+            "code": "InvalidDependencies",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -448,7 +484,11 @@ class TestOperators(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified dependencies are not valid."}
+        expected = {
+            "message": "The specified dependencies are not valid.",
+            "code": "InvalidDependencies",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -468,7 +508,11 @@ class TestOperators(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "Cyclical dependencies."}
+        expected = {
+            "message": "Cyclical dependencies.",
+            "code": "InvalidCyclicalDependencies",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -602,7 +646,11 @@ class TestOperators(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/operators/{operator_id}"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -618,7 +666,11 @@ class TestOperators(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/operators/{operator_id}"
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -634,7 +686,11 @@ class TestOperators(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/operators/{operator_id}"
         )
         result = rv.json()
-        expected = {"message": "The specified operator does not exist"}
+        expected = {
+            "message": "The specified operator does not exist",
+            "code": "OperatorNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -42,7 +42,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -61,7 +60,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -101,7 +99,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -126,7 +123,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -163,7 +159,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "source task does not exist",
             "code": "InvalidTaskId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -397,7 +392,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -418,7 +412,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -439,7 +432,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified operator does not exist",
             "code": "OperatorNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -463,7 +455,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified dependencies are not valid.",
             "code": "InvalidDependencies",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -487,7 +478,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified dependencies are not valid.",
             "code": "InvalidDependencies",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -511,7 +501,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "Cyclical dependencies.",
             "code": "InvalidCyclicalDependencies",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -649,7 +638,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -669,7 +657,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -689,7 +676,6 @@ class TestOperators(unittest.TestCase):
         expected = {
             "message": "The specified operator does not exist",
             "code": "OperatorNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -36,7 +36,11 @@ class TestParameters(unittest.TestCase):
 
         rv = TEST_CLIENT.get(f"/tasks/{task_id}/parameters")
         result = rv.json()
-        expected = {"message": "The specified task does not exist"}
+        expected = {
+            "message": "The specified task does not exist",
+            "code": "TaskNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -39,7 +39,6 @@ class TestParameters(unittest.TestCase):
         expected = {
             "message": "The specified task does not exist",
             "code": "TaskNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -43,7 +43,11 @@ class TestPredictions(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 404)
 
@@ -58,7 +62,11 @@ class TestPredictions(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/predictions"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 404)
 
@@ -73,7 +81,11 @@ class TestPredictions(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/predictions"
         )
         result = rv.json()
-        expected = {"message": "either form-data or json is required"}
+        expected = {
+            "message": "either form-data or json is required",
+            "code": "MissingRequiredFormDataOrJson",
+            "status_code": 400,
+        }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
 
@@ -88,7 +100,11 @@ class TestPredictions(unittest.TestCase):
             f"/projects/{project_id}/deployments/{deployment_id}/predictions", json={}
         )
         result = rv.json()
-        expected = {"message": "either dataset name or file is required"}
+        expected = {
+            "message": "either dataset name or file is required",
+            "code": "MissingRequiredDatasetOrFile",
+            "status_code": 400,
+        }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
 
@@ -109,7 +125,11 @@ class TestPredictions(unittest.TestCase):
             json={"dataset": name_dataset},
         )
         result = rv.json()
-        expected = {"message": "a valid dataset is required"}
+        expected = {
+            "message": "a valid dataset is required",
+            "code": "InvalidDataset",
+            "status_code": 400,
+        }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
 

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -46,7 +46,6 @@ class TestPredictions(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 404)
@@ -65,7 +64,6 @@ class TestPredictions(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 404)
@@ -84,7 +82,6 @@ class TestPredictions(unittest.TestCase):
         expected = {
             "message": "either form-data or json is required",
             "code": "MissingRequiredFormDataOrJson",
-            "status_code": 400,
         }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
@@ -103,7 +100,6 @@ class TestPredictions(unittest.TestCase):
         expected = {
             "message": "either dataset name or file is required",
             "code": "MissingRequiredDatasetOrFile",
-            "status_code": 400,
         }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
@@ -128,7 +124,6 @@ class TestPredictions(unittest.TestCase):
         expected = {
             "message": "a valid dataset is required",
             "code": "InvalidDataset",
-            "status_code": 400,
         }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -60,7 +60,6 @@ class TestProjects(unittest.TestCase):
         expected = {
             "message": "Invalid order argument",
             "code": "InvalidOrderBy",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -104,7 +103,6 @@ class TestProjects(unittest.TestCase):
         expected = {
             "message": "a project with that name already exists",
             "code": "ProjectNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -155,7 +153,6 @@ class TestProjects(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -196,7 +193,6 @@ class TestProjects(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -213,7 +209,6 @@ class TestProjects(unittest.TestCase):
         expected = {
             "message": "a project with that name already exists",
             "code": "ProjectNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -255,7 +250,6 @@ class TestProjects(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -302,7 +296,6 @@ class TestProjects(unittest.TestCase):
         expected = {
             "message": "inform at least one project",
             "code": "MissingRequiredProjectId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -57,7 +57,11 @@ class TestProjects(unittest.TestCase):
         rv = TEST_CLIENT.get("/projects?order=name unk")
         result = rv.json()
 
-        expected = {"message": "Invalid order argument"}
+        expected = {
+            "message": "Invalid order argument",
+            "code": "InvalidOrderBy",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -97,7 +101,11 @@ class TestProjects(unittest.TestCase):
         rv = TEST_CLIENT.post("/projects", json={"name": util.MOCK_PROJECT_NAME_1})
         result = rv.json()
 
-        expected = {"message": "a project with that name already exists"}
+        expected = {
+            "message": "a project with that name already exists",
+            "code": "ProjectNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -144,7 +152,11 @@ class TestProjects(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/projects/{project_id}")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -181,7 +193,11 @@ class TestProjects(unittest.TestCase):
         rv = TEST_CLIENT.patch(f"/projects/{project_id}", json={})
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -194,7 +210,11 @@ class TestProjects(unittest.TestCase):
         rv = TEST_CLIENT.patch(f"/projects/{project_id}", json={"name": project_name})
         result = rv.json()
 
-        expected = {"message": "a project with that name already exists"}
+        expected = {
+            "message": "a project with that name already exists",
+            "code": "ProjectNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -232,7 +252,11 @@ class TestProjects(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/projects/{project_id}")
         result = rv.json()
 
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -275,7 +299,11 @@ class TestProjects(unittest.TestCase):
         rv = TEST_CLIENT.post(f"/projects/deleteprojects", json=[])
         result = rv.json()
 
-        expected = {"message": "inform at least one project"}
+        expected = {
+            "message": "inform at least one project",
+            "code": "MissingRequiredProjectId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -44,7 +44,6 @@ class TestResponses(unittest.TestCase):
         expected = {
             "message": "The specified deployment does not exist",
             "code": "DeploymentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -41,7 +41,11 @@ class TestResponses(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "The specified deployment does not exist"}
+        expected = {
+            "message": "The specified deployment does not exist",
+            "code": "DeploymentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -44,7 +44,11 @@ class TestResults(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/results"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -60,45 +64,13 @@ class TestResults(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/results"
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
-
-    @mock.patch(
-        "kfp.Client",
-        return_value=util.MOCK_KFP_CLIENT,
-    )
-    @mock.patch.object(MINIO_CLIENT, "make_bucket")
-    @mock.patch.object(
-        MINIO_CLIENT,
-        "list_objects",
-        return_value=[],
-    )
-    def test_get_results_no_results(
-        self, mock_list_objects, mock_make_bucket, mock_kfp_client
-    ):
-        """
-        Should return an http status 404 and an error message.
-        """
-        project_id = util.MOCK_UUID_1
-        experiment_id = util.MOCK_UUID_1
-        run_id = "latest"
-
-        rv = TEST_CLIENT.get(
-            f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/results"
-        )
-        result = rv.json()
-        expected = {"message": "The specified run has no results"}
-        self.assertDictEqual(expected, result)
-        self.assertEqual(rv.status_code, 404)
-
-        mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_make_bucket.assert_any_call(BUCKET_NAME)
-        mock_list_objects.assert_any_call(
-            bucket_name=BUCKET_NAME,
-            prefix=f"experiments/{experiment_id}/operators/",
-            recursive=True,
-        )
 
     @mock.patch(
         "kfp.Client",
@@ -164,7 +136,11 @@ class TestResults(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/results"
         )
         result = rv.json()
-        expected = {"message": "The specified project does not exist"}
+        expected = {
+            "message": "The specified project does not exist",
+            "code": "ProjectNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -181,7 +157,11 @@ class TestResults(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/results"
         )
         result = rv.json()
-        expected = {"message": "The specified experiment does not exist"}
+        expected = {
+            "message": "The specified experiment does not exist",
+            "code": "ExperimentNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -198,46 +178,13 @@ class TestResults(unittest.TestCase):
             f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/results"
         )
         result = rv.json()
-        expected = {"message": "The specified operator does not exist"}
+        expected = {
+            "message": "The specified operator does not exist",
+            "code": "OperatorNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
-
-    @mock.patch(
-        "kfp.Client",
-        return_value=util.MOCK_KFP_CLIENT,
-    )
-    @mock.patch.object(MINIO_CLIENT, "make_bucket")
-    @mock.patch.object(
-        MINIO_CLIENT,
-        "list_objects",
-        return_value=[],
-    )
-    def test_get_operators_results_operator_no_results(
-        self, mock_list_objects, mock_make_bucket, mock_kfp_client
-    ):
-        """
-        Should return an http status 404 and an error message.
-        """
-        project_id = util.MOCK_UUID_1
-        experiment_id = util.MOCK_UUID_1
-        run_id = "latest"
-        operator_id = util.MOCK_UUID_1
-
-        rv = TEST_CLIENT.get(
-            f"/projects/{project_id}/experiments/{experiment_id}/runs/{run_id}/operators/{operator_id}/results"
-        )
-        result = rv.json()
-        expected = {"message": "The specified operator has no results"}
-        self.assertDictEqual(expected, result)
-        self.assertEqual(rv.status_code, 404)
-
-        mock_kfp_client.assert_any_call(host="http://ml-pipeline.kubeflow:8888")
-        mock_make_bucket.assert_any_call(BUCKET_NAME)
-        mock_list_objects.assert_any_call(
-            bucket_name=BUCKET_NAME,
-            prefix=f"experiments/{experiment_id}/operators/{operator_id}",
-            recursive=True,
-        )
 
     @mock.patch(
         "kfp.Client",

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -47,7 +47,6 @@ class TestResults(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -67,7 +66,6 @@ class TestResults(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -139,7 +137,6 @@ class TestResults(unittest.TestCase):
         expected = {
             "message": "The specified project does not exist",
             "code": "ProjectNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -160,7 +157,6 @@ class TestResults(unittest.TestCase):
         expected = {
             "message": "The specified experiment does not exist",
             "code": "ExperimentNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -181,7 +177,6 @@ class TestResults(unittest.TestCase):
         expected = {
             "message": "The specified operator does not exist",
             "code": "OperatorNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -84,7 +84,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "Invalid order argument",
             "code": "InvalidOrderBy",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -148,7 +147,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "a task with that name already exists",
             "code": "TaskNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -176,7 +174,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "Either provide notebooks or a task to copy from",
             "code": "MissingRequiredNotebookOrTaskId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -197,7 +194,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "source task does not exist",
             "code": "InvalidTaskId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -218,7 +214,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "invalid docker image name",
             "code": "InvalidDockerImageName",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -458,7 +453,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "The specified task does not exist",
             "code": "TaskNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -490,7 +484,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "The specified task does not exist",
             "code": "TaskNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -511,7 +504,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "a task with that name already exists",
             "code": "TaskNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -534,7 +526,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": f"Invalid category. Choose any of {valid_str}",
             "code": "InvalidCategory",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -793,7 +784,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "The specified task does not exist",
             "code": "TaskNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -810,7 +800,6 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "Task related to an operator",
             "code": "TaskProtectedFromDeletion",
-            "status_code": 403,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 403)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -41,7 +41,29 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 200)
 
+    def test_list_tasks_filter_name(self):
+        """
+        Should return a list of tasks sorted by name descending.
+        """
+        rv = TEST_CLIENT.get("/tasks?name=task")
+        result = rv.json()
+
+        expected = util.MOCK_TASK_LIST
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 200)
+
     def test_list_tasks_order_name_asc(self):
+        """
+        Should return a list of tasks sorted by name descending.
+        """
+        rv = TEST_CLIENT.get("/tasks?order=name asc")
+        result = rv.json()
+
+        expected = util.MOCK_TASK_LIST
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 200)
+
+    def test_list_tasks_order_name_desc(self):
         """
         Should return a list of tasks sorted by name descending.
         """
@@ -71,7 +93,7 @@ class TestTasks(unittest.TestCase):
         """
         Should return a list of tasks with one element.
         """
-        rv = TEST_CLIENT.get("/tasks?page_size=1&page=1")
+        rv = TEST_CLIENT.get("/tasks?page_size=1")
         result = rv.json()
 
         expected = {"tasks": [util.MOCK_TASK_1], "total": 1}
@@ -100,7 +122,7 @@ class TestTasks(unittest.TestCase):
     @mock.patch(
         "kubernetes.config.load_kube_config",
     )
-    def test_create_task_not_request_body(
+    def test_create_task_empty_request_body_success(
         self,
         mock_config_load,
         mock_core_v1_api,
@@ -126,6 +148,76 @@ class TestTasks(unittest.TestCase):
         expected = {
             "message": "a task with that name already exists",
             "code": "TaskNameExists",
+            "status_code": 400,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_create_task_notebook_or_task_id_error(self):
+        """
+        Should return http status 400 and a message 'Either provide notebooks or a task to copy from'.
+        """
+        task_id = util.MOCK_UUID_1
+        experiment_notebook = {
+            "cells": [],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 4,
+        }
+        rv = TEST_CLIENT.post(
+            "/tasks",
+            json={
+                "copyFrom": task_id,
+                "experimentNotebook": experiment_notebook,
+            },
+        )
+        result = rv.json()
+
+        expected = {
+            "message": "Either provide notebooks or a task to copy from",
+            "code": "MissingRequiredNotebookOrTaskId",
+            "status_code": 400,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_create_task_invalid_task_id_error(self):
+        """
+        Should return http status 400 and a message 'source task does not exist'.
+        """
+        task_id = "unk"
+        rv = TEST_CLIENT.post(
+            "/tasks",
+            json={
+                "copyFrom": task_id,
+            },
+        )
+        result = rv.json()
+
+        expected = {
+            "message": "source task does not exist",
+            "code": "InvalidTaskId",
+            "status_code": 400,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_create_task_invalid_docker_image_error(self):
+        """
+        Should return http status 400 and a message 'invalid docker image name'.
+        """
+        docker_image = "unk"
+        rv = TEST_CLIENT.post(
+            "/tasks",
+            json={
+                "image": docker_image,
+            },
+        )
+        result = rv.json()
+
+        expected = {
+            "message": "invalid docker image name",
+            "code": "InvalidDockerImageName",
             "status_code": 400,
         }
         self.assertDictEqual(expected, result)
@@ -424,6 +516,29 @@ class TestTasks(unittest.TestCase):
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
+    def test_update_task_invalid_category_error(self):
+        """
+        Should return a http error 400 and a message 'Invalid category. Choose any of {valid_str}'.
+        """
+        task_id = util.MOCK_UUID_4
+        category = "unk"
+
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "category": category,
+            },
+        )
+        result = rv.json()
+        valid_str = "DEFAULT,DATASETS,DESCRIPTIVE_STATISTICS,FEATURE_ENGINEERING,PREDICTOR,COMPUTER_VISION,NLP,MONITORING"
+        expected = {
+            "message": f"Invalid category. Choose any of {valid_str}",
+            "code": "InvalidCategory",
+            "status_code": 400,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 400)
+
     def test_update_task_unk_tags(self):
         """
         Should return a successfully updated task.
@@ -439,7 +554,7 @@ class TestTasks(unittest.TestCase):
         result = rv.json()
         expected = {
             "arguments": None,
-            "category": "DEFAULT",
+            "category": "MONITORING",
             "commands": None,
             "cpuLimit": "2000m",
             "cpuRequest": "100m",
@@ -492,7 +607,7 @@ class TestTasks(unittest.TestCase):
         result = rv.json()
         expected = {
             "arguments": None,
-            "category": "DEFAULT",
+            "category": "MONITORING",
             "commands": None,
             "cpuLimit": "2000m",
             "cpuRequest": "100m",
@@ -540,7 +655,7 @@ class TestTasks(unittest.TestCase):
             "cpuLimit": "2000m",
             "cpuRequest": "100m",
             "arguments": None,
-            "category": "DEFAULT",
+            "category": "MONITORING",
             "tags": ["FEATURE_ENGINEERING"],
             "dataIn": None,
             "dataOut": None,
@@ -592,7 +707,7 @@ class TestTasks(unittest.TestCase):
             "arguments": None,
             "cpuLimit": "2000m",
             "cpuRequest": "100m",
-            "category": "DEFAULT",
+            "category": "MONITORING",
             "tags": [],
             "dataIn": None,
             "dataOut": None,
@@ -682,6 +797,23 @@ class TestTasks(unittest.TestCase):
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
+
+    def test_delete_task_related_to_operator_error(self):
+        """
+        Should return a http error 403 and a message 'Task related to an operator'.
+        """
+        task_id = util.MOCK_UUID_1
+
+        rv = TEST_CLIENT.delete(f"/tasks/{task_id}")
+        result = rv.json()
+
+        expected = {
+            "message": "Task related to an operator",
+            "code": "TaskProtectedFromDeletion",
+            "status_code": 403,
+        }
+        self.assertDictEqual(expected, result)
+        self.assertEqual(rv.status_code, 403)
 
     @mock.patch(
         "kubernetes.client.CoreV1Api",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -59,7 +59,11 @@ class TestTasks(unittest.TestCase):
         rv = TEST_CLIENT.get("/tasks?order=name unk")
         result = rv.json()
 
-        expected = {"message": "Invalid order argument"}
+        expected = {
+            "message": "Invalid order argument",
+            "code": "InvalidOrderBy",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -119,7 +123,11 @@ class TestTasks(unittest.TestCase):
         rv = TEST_CLIENT.post("/tasks", json={"name": util.MOCK_TASK_NAME_1})
         result = rv.json()
 
-        expected = {"message": "a task with that name already exists"}
+        expected = {
+            "message": "a task with that name already exists",
+            "code": "TaskNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -355,7 +363,11 @@ class TestTasks(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/tasks/{task_id}")
         result = rv.json()
 
-        expected = {"message": "The specified task does not exist"}
+        expected = {
+            "message": "The specified task does not exist",
+            "code": "TaskNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -383,7 +395,11 @@ class TestTasks(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "The specified task does not exist"}
+        expected = {
+            "message": "The specified task does not exist",
+            "code": "TaskNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -400,7 +416,11 @@ class TestTasks(unittest.TestCase):
             },
         )
         result = rv.json()
-        expected = {"message": "a task with that name already exists"}
+        expected = {
+            "message": "a task with that name already exists",
+            "code": "TaskNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -655,7 +675,11 @@ class TestTasks(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/tasks/{task_id}")
         result = rv.json()
 
-        expected = {"message": "The specified task does not exist"}
+        expected = {
+            "message": "The specified task does not exist",
+            "code": "TaskNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -59,7 +59,9 @@ class TestTemplates(unittest.TestCase):
         result = rv.json()
 
         expected = {
-            "message": "experimentId or deploymentId needed to create template."
+            "message": "experimentId or deploymentId needed to create template.",
+            "code": "MissingRequiredExperimentIdOrDeploymentId",
+            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -80,7 +82,11 @@ class TestTemplates(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "a template with that name already exists"}
+        expected = {
+            "message": "a template with that name already exists",
+            "code": "TemplateNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -172,7 +178,11 @@ class TestTemplates(unittest.TestCase):
         rv = TEST_CLIENT.get(f"/templates/{template_id}")
         result = rv.json()
 
-        expected = {"message": "The specified template does not exist"}
+        expected = {
+            "message": "The specified template does not exist",
+            "code": "TemplateNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -198,7 +208,11 @@ class TestTemplates(unittest.TestCase):
         rv = TEST_CLIENT.patch(f"/templates/{template_id}", json={})
         result = rv.json()
 
-        expected = {"message": "The specified template does not exist"}
+        expected = {
+            "message": "The specified template does not exist",
+            "code": "TemplateNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -213,7 +227,11 @@ class TestTemplates(unittest.TestCase):
         )
         result = rv.json()
 
-        expected = {"message": "a template with that name already exists"}
+        expected = {
+            "message": "a template with that name already exists",
+            "code": "TemplateNameExists",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 
@@ -258,7 +276,11 @@ class TestTemplates(unittest.TestCase):
         rv = TEST_CLIENT.delete(f"/templates/{template_id}")
         result = rv.json()
 
-        expected = {"message": "The specified template does not exist"}
+        expected = {
+            "message": "The specified template does not exist",
+            "code": "TemplateNotFound",
+            "status_code": 404,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
 
@@ -281,7 +303,11 @@ class TestTemplates(unittest.TestCase):
         rv = TEST_CLIENT.post(f"/templates/deletetemplates", json=[])
         result = rv.json()
 
-        expected = {"message": "inform at least one template"}
+        expected = {
+            "message": "inform at least one template",
+            "code": "MissingRequiredTemplateId",
+            "status_code": 400,
+        }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -61,7 +61,6 @@ class TestTemplates(unittest.TestCase):
         expected = {
             "message": "experimentId or deploymentId needed to create template.",
             "code": "MissingRequiredExperimentIdOrDeploymentId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -85,7 +84,6 @@ class TestTemplates(unittest.TestCase):
         expected = {
             "message": "a template with that name already exists",
             "code": "TemplateNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -181,7 +179,6 @@ class TestTemplates(unittest.TestCase):
         expected = {
             "message": "The specified template does not exist",
             "code": "TemplateNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -211,7 +208,6 @@ class TestTemplates(unittest.TestCase):
         expected = {
             "message": "The specified template does not exist",
             "code": "TemplateNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -230,7 +226,6 @@ class TestTemplates(unittest.TestCase):
         expected = {
             "message": "a template with that name already exists",
             "code": "TemplateNameExists",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)
@@ -279,7 +274,6 @@ class TestTemplates(unittest.TestCase):
         expected = {
             "message": "The specified template does not exist",
             "code": "TemplateNotFound",
-            "status_code": 404,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 404)
@@ -306,7 +300,6 @@ class TestTemplates(unittest.TestCase):
         expected = {
             "message": "inform at least one template",
             "code": "MissingRequiredTemplateId",
-            "status_code": 400,
         }
         self.assertDictEqual(expected, result)
         self.assertEqual(rv.status_code, 400)

--- a/tests/util.py
+++ b/tests/util.py
@@ -663,7 +663,7 @@ MOCK_TASK_4 = {
 
 MOCK_TASK_5 = {
     "arguments": None,
-    "category": "DEFAULT",
+    "category": "MONITORING",
     "commands": None,
     "cpuLimit": models.task.TASK_DEFAULT_CPU_LIMIT,
     "cpuRequest": models.task.TASK_DEFAULT_CPU_REQUEST,
@@ -894,7 +894,7 @@ def create_mocks():
         models.Task(
             uuid=MOCK_UUID_5,
             name=MOCK_TASK_NAME_5,
-            category="DEFAULT",
+            category="MONITORING",
             tags=[],
             created_at=MOCK_CREATED_AT_4,
             updated_at=MOCK_UPDATED_AT_4,


### PR DESCRIPTION
Adds instructions on how to create/document error messages for APIs 

Modifies CODE-REVIEW.md with these instructions.
 
Adds Error Responses to docs/swagger.yaml 

All errors have a code, a message, and a status (code).
This will improve the maintainability of our APIs when integrating
with other systems (eg. Frontend).

Adds code and status_code to existing ApiExceptions 

Adds CannotCreateNamespacedPod to docs/swagger.yaml

Adds code and status_code to InternalServerError, ServiceUnavailable, and Forbidden exceptions
 
Fix mispell 'comparision' -> 'comparison'

Adds code and status_code to NotFound exceptions

Adds DeploymentNameExists response to swagger docs

Adds code and status_code to BadRequest exceptions

Replaces inadequate 'NotFound' exceptions by 'BadRequest' exceptions 

HTTP Status 404 NotFound should be returned when a resource ID (provided in the URL)
does not exist.
When dealing with resources that are sent in the request body, one should
return HTTP Status 400 BadRequest.

Adds DatasetNotFound exception to docs/swagger.yaml

Adapts unittests to new returns 'code' and 'status_code'