### PR TITLE
Added timezone in the timestamp of projects, experiments and deployments

### DIFF
--- a/projects/models/comparison.py
+++ b/projects/models/comparison.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Comparison model."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, ForeignKey, JSON, String
 
 from projects.database import Base
+from projects.utils import TimeStamp
 
 
 class Comparison(Base):
@@ -16,5 +17,6 @@ class Comparison(Base):
     active_tab = Column(String(10), nullable=False, default='1')
     run_id = Column(String(255))
     layout = Column(JSON)
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = Column(TimeStamp(), nullable=False, default=now)
+    updated_at = Column(TimeStamp(), nullable=False, default=now)

--- a/projects/models/comparison.py
+++ b/projects/models/comparison.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, ForeignKey, JSON, String
 
 from projects.database import Base
-from projects.utils import TimeStamp
+from projects.utils import TimeStamp, now
 
 
 class Comparison(Base):
@@ -17,6 +17,5 @@ class Comparison(Base):
     active_tab = Column(String(10), nullable=False, default='1')
     run_id = Column(String(255))
     layout = Column(JSON)
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
-    created_at = Column(TimeStamp(), nullable=False, default=now)
-    updated_at = Column(TimeStamp(), nullable=False, default=now)
+    created_at = Column(TimeStamp(), nullable=False, default=now())
+    updated_at = Column(TimeStamp(), nullable=False, default=now())

--- a/projects/models/deployment.py
+++ b/projects/models/deployment.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Deployment model."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     Boolean,
@@ -17,6 +17,8 @@ from sqlalchemy.sql import expression
 from projects.database import Base
 from projects.models.monitoring import Monitoring
 from projects.models.operator import Operator
+from projects.utils import TimeStamp
+
 
 CASCADE = "all, delete-orphan"
 
@@ -24,7 +26,9 @@ CASCADE = "all, delete-orphan"
 class Deployment(Base):
     __tablename__ = "deployments"
     uuid = Column(String(255), primary_key=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = Column(TimeStamp(), nullable=False, default=now)
+    updated_at = Column(TimeStamp(), nullable=False, default=now)
     experiment_id = Column(String(255), ForeignKey("experiments.uuid"), nullable=True)
     is_active = Column(Boolean, nullable=False, server_default=expression.true())
     name = Column(Text, nullable=False)
@@ -44,4 +48,3 @@ class Deployment(Base):
     project_id = Column(
         String(255), ForeignKey("projects.uuid"), nullable=False, index=True
     )
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/projects/models/deployment.py
+++ b/projects/models/deployment.py
@@ -17,7 +17,7 @@ from sqlalchemy.sql import expression
 from projects.database import Base
 from projects.models.monitoring import Monitoring
 from projects.models.operator import Operator
-from projects.utils import TimeStamp
+from projects.utils import TimeStamp, now
 
 
 CASCADE = "all, delete-orphan"
@@ -26,9 +26,8 @@ CASCADE = "all, delete-orphan"
 class Deployment(Base):
     __tablename__ = "deployments"
     uuid = Column(String(255), primary_key=True)
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
-    created_at = Column(TimeStamp(), nullable=False, default=now)
-    updated_at = Column(TimeStamp(), nullable=False, default=now)
+    created_at = Column(TimeStamp(), nullable=False, default=now())
+    updated_at = Column(TimeStamp(), nullable=False, default=now())
     experiment_id = Column(String(255), ForeignKey("experiments.uuid"), nullable=True)
     is_active = Column(Boolean, nullable=False, server_default=expression.true())
     name = Column(Text, nullable=False)

--- a/projects/models/experiment.py
+++ b/projects/models/experiment.py
@@ -10,7 +10,7 @@ from projects.models.comparison import Comparison
 from projects.models.deployment import Deployment
 from projects.models.operator import Operator
 from projects.database import Base
-from projects.utils import TimeStamp
+from projects.utils import TimeStamp, now
 
 
 class Experiment(Base):
@@ -20,9 +20,8 @@ class Experiment(Base):
     project_id = Column(String(255), ForeignKey("projects.uuid"), nullable=False, index=True)
     position = Column(Integer, nullable=False, default=-1)
     is_active = Column(Boolean, nullable=False, server_default=expression.true())
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
-    created_at = Column(TimeStamp(), nullable=False, default=now)
-    updated_at = Column(TimeStamp(), nullable=False, default=now)
+    created_at = Column(TimeStamp(), nullable=False, default=now())
+    updated_at = Column(TimeStamp(), nullable=False, default=now())
     operators = relationship("Operator",
                              backref="experiment",
                              primaryjoin=uuid == Operator.experiment_id,

--- a/projects/models/experiment.py
+++ b/projects/models/experiment.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Experiment model."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, ForeignKey
 from sqlalchemy.orm import relationship
@@ -10,6 +10,7 @@ from projects.models.comparison import Comparison
 from projects.models.deployment import Deployment
 from projects.models.operator import Operator
 from projects.database import Base
+from projects.utils import TimeStamp
 
 
 class Experiment(Base):
@@ -19,8 +20,9 @@ class Experiment(Base):
     project_id = Column(String(255), ForeignKey("projects.uuid"), nullable=False, index=True)
     position = Column(Integer, nullable=False, default=-1)
     is_active = Column(Boolean, nullable=False, server_default=expression.true())
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = Column(TimeStamp(), nullable=False, default=now)
+    updated_at = Column(TimeStamp(), nullable=False, default=now)
     operators = relationship("Operator",
                              backref="experiment",
                              primaryjoin=uuid == Operator.experiment_id,

--- a/projects/models/operator.py
+++ b/projects/models/operator.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """Operator model."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, Float, ForeignKey, JSON, String, Text
 from sqlalchemy.orm import backref, relationship
 
 from projects.database import Base
+from projects.utils import TimeStamp
 
 
 class Operator(Base):
@@ -21,6 +22,7 @@ class Operator(Base):
     status_message = Column(String(255), nullable=True)
     position_x = Column("position_x", Float, nullable=True)
     position_y = Column("position_y", Float, nullable=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = Column(TimeStamp(), nullable=False, default=now)
+    updated_at = Column(TimeStamp(), nullable=False, default=now)
     task = relationship("Task", backref=backref("operator", uselist=False))

--- a/projects/models/project.py
+++ b/projects/models/project.py
@@ -10,7 +10,7 @@ from projects.database import Base
 from projects.models.deployment import Deployment
 from projects.models.experiment import Experiment
 from projects.models.comparison import Comparison
-from projects.utils import TimeStamp
+from projects.utils import TimeStamp, now
 
 
 CASCADE_BEHAVIOR = "all, delete-orphan"
@@ -20,9 +20,8 @@ class Project(Base):
     __tablename__ = "projects"
     uuid = Column(String(255), primary_key=True)
     name = Column(Text, nullable=False)
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
-    created_at = Column(TimeStamp(), nullable=False, default=now)
-    updated_at = Column(TimeStamp(), nullable=False, default=now)
+    created_at = Column(TimeStamp(), nullable=False, default=now())
+    updated_at = Column(TimeStamp(), nullable=False, default=now())
     description = Column(Text)
     experiments = relationship("Experiment",
                                primaryjoin=uuid == Experiment.project_id,

--- a/projects/models/project.py
+++ b/projects/models/project.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Project model."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, String, Text
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -10,6 +10,8 @@ from projects.database import Base
 from projects.models.deployment import Deployment
 from projects.models.experiment import Experiment
 from projects.models.comparison import Comparison
+from projects.utils import TimeStamp
+
 
 CASCADE_BEHAVIOR = "all, delete-orphan"
 
@@ -18,8 +20,9 @@ class Project(Base):
     __tablename__ = "projects"
     uuid = Column(String(255), primary_key=True)
     name = Column(Text, nullable=False)
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = Column(TimeStamp(), nullable=False, default=now)
+    updated_at = Column(TimeStamp(), nullable=False, default=now)
     description = Column(Text)
     experiments = relationship("Experiment",
                                primaryjoin=uuid == Experiment.project_id,

--- a/projects/models/template.py
+++ b/projects/models/template.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, JSON, String, Text
 
 from projects.database import Base
-from projects.utils import TimeStamp
+from projects.utils import TimeStamp, now
 
 
 class Template(Base):
@@ -15,7 +15,6 @@ class Template(Base):
     tasks = Column(JSON, nullable=False, default=[])
     experiment_id = Column(String(255), nullable=True)
     deployment_id = Column(String(255), nullable=True)
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
-    created_at = Column(TimeStamp(), nullable=False, default=now)
-    updated_at = Column(TimeStamp(), nullable=False, default=now)
+    created_at = Column(TimeStamp(), nullable=False, default=now())
+    updated_at = Column(TimeStamp(), nullable=False, default=now())
     tenant = Column(String(255), nullable=True)

--- a/projects/models/template.py
+++ b/projects/models/template.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Template model."""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, JSON, String, Text
 
 from projects.database import Base
+from projects.utils import TimeStamp
 
 
 class Template(Base):
@@ -14,6 +15,7 @@ class Template(Base):
     tasks = Column(JSON, nullable=False, default=[])
     experiment_id = Column(String(255), nullable=True)
     deployment_id = Column(String(255), nullable=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    created_at = Column(TimeStamp(), nullable=False, default=now)
+    updated_at = Column(TimeStamp(), nullable=False, default=now)
     tenant = Column(String(255), nullable=True)

--- a/projects/utils.py
+++ b/projects/utils.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qsl
 from datetime import datetime, timezone
 import sqlalchemy as sa
 
+
 def to_camel_case(snake_str):
     """
     Transforms a snake_case string into camelCase.
@@ -76,6 +77,7 @@ def format_query_params(query_params):
 
 class TimeStamp(sa.types.TypeDecorator):
     impl = sa.types.DateTime
+
     def process_bind_param(self, value: datetime, dialect):
         if value.tzinfo is None:
             value = value.astimezone(timezone.utc)
@@ -87,3 +89,7 @@ class TimeStamp(sa.types.TypeDecorator):
             return value.replace(tzinfo=timezone.utc)
 
         return value.astimezone(timezone.utc)
+
+
+def now():
+    return datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/projects/utils.py
+++ b/projects/utils.py
@@ -3,7 +3,8 @@
 import re
 from itertools import chain
 from urllib.parse import parse_qsl
-
+from datetime import datetime, timezone
+import sqlalchemy as sa
 
 def to_camel_case(snake_str):
     """
@@ -71,3 +72,18 @@ def format_query_params(query_params):
     dict
     """
     return dict(parse_qsl(query_params))
+
+
+class TimeStamp(sa.types.TypeDecorator):
+    impl = sa.types.DateTime
+    def process_bind_param(self, value: datetime, dialect):
+        if value.tzinfo is None:
+            value = value.astimezone(timezone.utc)
+
+        return value.astimezone(timezone.utc)
+
+    def process_result_value(self, value, dialect):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+
+        return value.astimezone(timezone.utc)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -290,7 +290,7 @@ class TestProjects(unittest.TestCase):
         """
         Should return a http error 400 and a message 'inform at least one project'.
         """
-        rv = TEST_CLIENT.post(f"/projects/deleteprojects", json=[])
+        rv = TEST_CLIENT.post("/projects/deleteprojects", json=[])
         result = rv.json()
 
         expected = {
@@ -321,7 +321,7 @@ class TestProjects(unittest.TestCase):
         project_id_2 = util.MOCK_UUID_2
 
         rv = TEST_CLIENT.post(
-            f"/projects/deleteprojects", json=[project_id_1, project_id_2]
+            "/projects/deleteprojects", json=[project_id_1, project_id_2]
         )
         result = rv.json()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import unittest
+import pytest
+
+
+from projects import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_to_camel_case(self):
+        snake = "test_to_camel_case"
+        camel = "testToCamelCase"
+        self.assertEqual(utils.to_camel_case(snake), camel)
+
+    def test_to_snake_case(self):
+        snake = "test_to_camel_case"
+        camel = "testToCamelCase"
+        self.assertEqual(utils.to_snake_case(camel), snake)

--- a/tests/util.py
+++ b/tests/util.py
@@ -305,6 +305,7 @@ MOCK_TEMPLATE_NAME_1, MOCK_TEMPLATE_NAME_2 = "template-1", "template-2"
     now,
     now,
     now,
+    now
 )
 (
     MOCK_UPDATED_AT_1,
@@ -319,6 +320,7 @@ MOCK_TEMPLATE_NAME_1, MOCK_TEMPLATE_NAME_2 = "template-1", "template-2"
     now,
     now,
     now,
+    now
 )
 
 MOCK_OPERATOR_1 = {

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 from kfp_server_api.rest import ApiException
 import json
@@ -286,6 +286,8 @@ MOCK_DEPLOYMENT_NAME_1, MOCK_DEPLOYMENT_NAME_2 = "deployment-1", "deployment-2"
     "task-4",
     "task-5",
 )
+now = datetime.utcnow()
+now = now.replace(tzinfo=timezone.utc)
 MOCK_TEMPLATE_NAME_1, MOCK_TEMPLATE_NAME_2 = "template-1", "template-2"
 (
     MOCK_CREATED_AT_1,
@@ -294,11 +296,11 @@ MOCK_TEMPLATE_NAME_1, MOCK_TEMPLATE_NAME_2 = "template-1", "template-2"
     MOCK_CREATED_AT_4,
     MOCK_CREATED_AT_5,
 ) = (
-    datetime.utcnow(),
-    datetime.utcnow(),
-    datetime.utcnow(),
-    datetime.utcnow(),
-    datetime.utcnow(),
+    now,
+    now,
+    now,
+    now,
+    now,
 )
 (
     MOCK_UPDATED_AT_1,
@@ -307,11 +309,11 @@ MOCK_TEMPLATE_NAME_1, MOCK_TEMPLATE_NAME_2 = "template-1", "template-2"
     MOCK_UPDATED_AT_4,
     MOCK_UPDATED_AT_5,
 ) = (
-    datetime.utcnow(),
-    datetime.utcnow(),
-    datetime.utcnow(),
-    datetime.utcnow(),
-    datetime.utcnow(),
+    now,
+    now,
+    now,
+    now,
+    now,
 )
 
 MOCK_OPERATOR_1 = {


### PR DESCRIPTION
Reprodução:

Implantar um fluxo (com computador no horário de brasília)
Resultado (foto em anexo)

No canto superior o horário local, e no campo “Data de criação”, 3 horas adiantado)

 

ANÁLISE DE ERRO: 
O backend da plataforma retorna as datas no fuso "UTC", porém usa formatação errada, pois a hora não termina com "Z" ou "+00:00".

DESIGN DE SOLUÇÃO:
Adicionar a informação de timezone ("Z" ou "+00:00") nos atributos updated_at e created_at nas APIs.

![image](https://user-images.githubusercontent.com/30246766/144162946-9de98141-608c-42b8-ba3d-9b1c86d901ef.png)
