### PR TITLE
PLATIA-2265/feature/deletion-as-job

### DIFF
--- a/projects/api/tasks/tasks.py
+++ b/projects/api/tasks/tasks.py
@@ -123,7 +123,6 @@ async def handle_patch_task(
 @router.delete("/{task_id}")
 async def handle_delete_task(
     task_id: str,
-    background_tasks: BackgroundTasks,
     session: Session = Depends(database.session_scope),
 ):
     """
@@ -139,7 +138,7 @@ async def handle_delete_task(
     -------
     projects.schemas.message.Message
     """
-    task_controller = TaskController(session, background_tasks)
+    task_controller = TaskController(session)
     result = task_controller.delete_task(task_id=task_id)
     return result
 

--- a/projects/controllers/tasks/tasks.py
+++ b/projects/controllers/tasks/tasks.py
@@ -16,11 +16,9 @@ from sqlalchemy import asc, desc, func
 from projects import __version__, models, schemas
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, Forbidden, InternalServerError, NotFound
-from projects.kfp.kfp import kfp_client
 from projects.kubernetes.notebook import (
     copy_file_to_pod,
     get_files_from_task,
-    remove_persistent_volume_claim,
     update_persistent_volume_claim,
     update_task_config_map,
 )

--- a/projects/controllers/tasks/tasks.py
+++ b/projects/controllers/tasks/tasks.py
@@ -16,6 +16,7 @@ from sqlalchemy import asc, desc, func
 from projects import __version__, models, schemas
 from projects.controllers.utils import uuid_alpha
 from projects.exceptions import BadRequest, Forbidden, NotFound
+from projects.kfp.kfp import kfp_client
 from projects.kubernetes.notebook import (
     copy_file_to_pod,
     get_files_from_task,
@@ -23,7 +24,9 @@ from projects.kubernetes.notebook import (
     update_persistent_volume_claim,
     update_task_config_map,
 )
-from projects.kfp.tasks import make_task_creation_job
+from projects.kfp.tasks import make_task_creation_job, make_task_deletion_job
+from projects.kfp import KF_PIPELINES_NAMESPACE
+
 
 PREFIX = "tasks"
 
@@ -201,7 +204,6 @@ class TaskController:
         """
         # for now we need import here to avoid circular import
         # from projects.kfp.tasks import make_task_creation_job
-        from projects.kfp import KF_PIPELINES_NAMESPACE
 
         has_notebook = task.experiment_notebook or task.deployment_notebook
 
@@ -450,10 +452,10 @@ class TaskController:
 
         # remove the volume for the task in the notebook server
         all_tasks = self.session.query(models.Task).all()
-        kfp.delete_task(
+        make_task_deletion_job(
             task=task,
             all_tasks=all_tasks,
-            namespace=self.kubeflow_userid,
+            namespace=KF_PIPELINES_NAMESPACE,
         )
 
         return schemas.Message(message="Task deleted")

--- a/projects/controllers/tasks/tasks.py
+++ b/projects/controllers/tasks/tasks.py
@@ -451,14 +451,14 @@ class TaskController:
 
         # remove the volume for the task in the notebook server
         all_tasks = self.session.query(models.Task).all()
+        self.session.delete(task)
+        self.session.commit()
         try:
             make_task_deletion_job(
                 task=task,
                 all_tasks=all_tasks,
                 namespace=KF_PIPELINES_NAMESPACE,
             )
-            self.session.delete(task)
-            self.session.commit()
         except Exception as e:
             raise InternalServerError(
                 code="DeletionJobError",

--- a/projects/kfp/tasks.py
+++ b/projects/kfp/tasks.py
@@ -113,7 +113,7 @@ def make_task_creation_job(
     )
 
 
-def make_task_deletion_jobk(
+def make_task_deletion_job(
     task: models.Task, all_tasks: List[models.Task], namespace: str
 ):
     """
@@ -144,7 +144,7 @@ def make_task_deletion_jobk(
 
     run_name = f"Delete Task - {task.name}"
 
-    return kfp_client(namespace).create_run_from_pipeline_func(
+    return kfp_client().create_run_from_pipeline_func(
         pipeline_func=pipeline_func,
         arguments={},
         run_name=run_name,

--- a/projects/kfp/volume.py
+++ b/projects/kfp/volume.py
@@ -3,6 +3,7 @@
 A module that provides functions that handle volume operations.
 """
 from kfp import dsl
+from kfp.dsl._resource_op import kubernetes_resource_delete_op
 from kubernetes.client.models import V1PersistentVolumeClaim
 
 
@@ -41,4 +42,23 @@ def create_volume_op(name: str, namespace: str, storage: str = "10Gi"):
         name=f"vol-{name}",
         k8s_resource=pvc,
         action="apply",
+    )
+
+
+def delete_volume_op(name: str, namespace: str):
+    """
+    Creates a kfp.dsl.ContainerOp that deletes a volume (Kubernetes Resource).
+    Parameters
+    ----------
+    name : str
+    namespace : str
+    Returns
+    -------
+    kfp.dsl.ContainerOp
+    """
+    kind = "PersistentVolumeClaim"
+    return kubernetes_resource_delete_op(
+        name=f"vol-{name}",
+        kind=kind,
+        namespace=namespace,
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -14,8 +14,10 @@ from projects.kfp.tasks import (
     create_configmap_op,
     make_task_creation_job,
     patch_notebook_volume_mounts_op,
+    delete_volume_op
 )
 from projects.kfp import KF_PIPELINES_NAMESPACE
+from projects.kfp.volume import delete_volume_op
 
 import tests.util as util
 
@@ -807,3 +809,6 @@ class TestTasks(unittest.TestCase):
 
         expected = {"message": "Task deleted"}
         self.assertDictEqual(expected, result)
+
+    def test_deletion_component_functions_from(self,):
+        delete_volume_op(name=f"task-{util.MOCK_UUID_4}", namespace=KF_PIPELINES_NAMESPACE)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -12,9 +12,7 @@ from projects.kfp.tasks import (
     make_task_creation_job,
     create_init_task_container_op,
     create_configmap_op,
-    make_task_creation_job,
     patch_notebook_volume_mounts_op,
-    delete_volume_op
 )
 from projects.kfp import KF_PIPELINES_NAMESPACE
 from projects.kfp.volume import delete_volume_op

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -268,6 +268,7 @@ class TestTasks(unittest.TestCase):
     )
     # we will test those function by running them, not need to assert their result
     def test_task_creation_component_functions(self, mock_kfp_client):
+        
         task = util.TestingSessionLocal().query(models.Task).get(util.MOCK_UUID_6)
         all_tasks = util.TestingSessionLocal().query(models.Task).all()
         source_task = (
@@ -336,7 +337,7 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 200)
 
-    #  mock_kfp_client.assert_any_call(host=HOST_URL)
+        mock_kfp_client.assert_any_call(host=HOST_URL)
 
     @mock.patch(
         "kfp.Client",
@@ -810,5 +811,6 @@ class TestTasks(unittest.TestCase):
         expected = {"message": "Task deleted"}
         self.assertDictEqual(expected, result)
 
+    # we will test those function by running them, not need to assert their result
     def test_deletion_component_functions_from(self,):
         delete_volume_op(name=f"task-{util.MOCK_UUID_4}", namespace=KF_PIPELINES_NAMESPACE)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -263,18 +263,18 @@ class TestTasks(unittest.TestCase):
     @mock.patch(
         "kfp.Client",
         return_value=util.MOCK_KFP_CLIENT,
-    )    
+    )
     # we will test those function by running them, not need to assert their result
-    def test_task_creation_component_functions(
-        self,mock_kfp_client
-    ):
+    def test_task_creation_component_functions(self, mock_kfp_client):
         task = util.TestingSessionLocal().query(models.Task).get(util.MOCK_UUID_6)
         all_tasks = util.TestingSessionLocal().query(models.Task).all()
         source_task = (
             util.TestingSessionLocal().query(models.Task).get(util.MOCK_UUID_1)
         )
-        
-        make_task_creation_job(task=task, all_tasks=all_tasks, namespace=KF_PIPELINES_NAMESPACE)
+
+        make_task_creation_job(
+            task=task, all_tasks=all_tasks, namespace=KF_PIPELINES_NAMESPACE
+        )
 
         # empty task case
         create_init_task_container_op()
@@ -790,21 +790,12 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(rv.status_code, 403)
 
     @mock.patch(
-        "kubernetes.client.CoreV1Api",
-        return_value=util.MOCK_CORE_V1_API,
-    )
-    @mock.patch(
-        "kubernetes.client.CustomObjectsApi",
-        return_value=util.MOCK_CUSTOM_OBJECTS_API,
-    )
-    @mock.patch(
-        "kubernetes.config.load_kube_config",
+        "kfp.Client",
+        return_value=util.MOCK_KFP_CLIENT,
     )
     def test_delete_task_success(
         self,
-        mock_config_load,
-        mock_custom_objects_api,
-        mock_core_v1_api,
+        mock_kfp_client,
     ):
         """
         Should delete task successfully.
@@ -816,7 +807,3 @@ class TestTasks(unittest.TestCase):
 
         expected = {"message": "Task deleted"}
         self.assertDictEqual(expected, result)
-
-        mock_core_v1_api.assert_any_call()
-        mock_custom_objects_api.assert_any_call(api_client=mock.ANY)
-        mock_config_load.assert_any_call()


### PR DESCRIPTION
JIRA: https://jira.cpqd.com.br/browse/PLATIA-2265

Atualmente a PlatIA utiliza a funcionalidade backgroundTasks como forma de manter a assincronicidade das operações, entretanto, diversos problemas vem ocorrendo nessa metodologia. Dito isto, esse pull request intenta 'terceirizar' a deleção de tarefas para o kubeflow através do kfp e por consequência tirar a sobrecarga de operações do FastAPI.