### PR TITLE
Feature/task tags restriction

### DIFF
--- a/projects/api/tasks/tasks.py
+++ b/projects/api/tasks/tasks.py
@@ -94,7 +94,7 @@ async def handle_get_task(
 @router.patch("/{task_id}", response_model=projects.schemas.task.Task)
 async def handle_patch_task(
     task_id: str,
-    task: projects.schemas.task.TaskUpdate,
+    task: projects.schemas.task.TaskCreate,
     background_tasks: BackgroundTasks,
     session: Session = Depends(database.session_scope),
 ):
@@ -104,7 +104,7 @@ async def handle_patch_task(
     Parameters
     ----------
     task_id : str
-    task : projects.schemas.task.TaskUpdate
+    task : projects.schemas.task.TaskCreate
     background_tasks : fastapi.BackgroundTasks
     session : sqlalchemy.orm.session.Session
 

--- a/projects/controllers/tasks/tasks.py
+++ b/projects/controllers/tasks/tasks.py
@@ -312,13 +312,13 @@ class TaskController:
 
         return schemas.Task.from_orm(task)
 
-    def update_task(self, task: schemas.TaskUpdate, task_id: str):
+    def update_task(self, task: schemas.TaskCreate, task_id: str):
         """
         Updates a task in our database/object storage.
 
         Parameters
         ----------
-        task: projects.schemas.task.TaskUpdate
+        task: projects.schemas.task.TaskCreate
         task_id : str
 
         Returns
@@ -474,11 +474,11 @@ class TaskController:
 
     def copy_notebooks_to_pod(self, task, stored_task):
         """
-        Copies the notebook contents to the pod (if it was sent on TaskUpdate).
+        Copies the notebook contents to the pod (if it was sent on TaskCreate).
 
         Parameters
         ----------
-        task : projects.schemas.task.TaskUpdate
+        task : projects.schemas.task.TaskCreate
         stored_task : projects.models.task.Task
         """
         filepaths = list()

--- a/projects/schemas/__init__.py
+++ b/projects/schemas/__init__.py
@@ -7,6 +7,6 @@ from .monitoring import Monitoring, MonitoringCreate, MonitoringList, Monitoring
 from .operator import Operator, OperatorCreate, OperatorList, OperatorUpdate, Parameter
 from .project import Project, ProjectCreate, ProjectList, ProjectUpdate
 from .run import Run, RunList
-from .task import Task, TaskCreate, TaskList, TaskUpdate
+from .task import Task, TaskCreate, TaskList
 from .template import Template, TemplateCreate, TemplateList, TemplateUpdate
 from .prediction import Prediction, PredictionBase

--- a/projects/schemas/task.py
+++ b/projects/schemas/task.py
@@ -88,67 +88,6 @@ class TaskCreate(TaskBase):
         return v
 
 
-class TaskUpdate(TaskBase):
-    name: Optional[str]
-    description: Optional[str]
-    category: Optional[str]
-    tags: Optional[List[str]]
-    data_in: Optional[str]
-    data_out: Optional[str]
-    docs: Optional[str]
-    image: Optional[str]
-    commands: Optional[List[str]]
-    arguments: Optional[List[str]]
-    parameters: Optional[List]
-    experiment_notebook: Optional[Dict]
-    deployment_notebook: Optional[Dict]
-    experiment_notebook_path: Optional[str]
-    deployment_notebook_path: Optional[str]
-    cpu_limit: Optional[str]
-    cpu_request: Optional[str]
-    memory_limit: Optional[str]
-    memory_request: Optional[str]
-
-    @validator("name")
-    def validate_name(cls, v):
-        generic_validators.raise_if_exceeded(MAX_CHARS_ALLOWED, v)
-        generic_validators.raise_if_forbidden_character(FORBIDDEN_CHARACTERS_REGEX, v)
-        return v
-
-    @validator("description")
-    def validate_description(cls, v):
-        generic_validators.raise_if_exceeded(MAX_CHARS_ALLOWED_DESCRIPTION, v)
-        return v
-    @validator("tags")
-    def validate_tags(cls, v):
-        if len(v) > MAX_TAGS_ALLOWED:
-            raise BadRequest(
-                code="ExceededTagAmount",
-                message="Tag quantity exceeded maximum allowed",
-            )
-
-        for tag in v:
-            generic_validators.raise_if_exceeded(MAX_CHARS_ALLOWED, tag)
-            generic_validators.raise_if_forbidden_character(
-                FORBIDDEN_CHARACTERS_REGEX, tag
-            )
-
-        return v
-
-    @validator("data_in", "data_out", each_item=True)
-    def validate_data_in_out(cls, v):
-        generic_validators.raise_if_exceeded(MAX_CHARS_ALLOWED_DATA, v)
-        return v
-
-    @validator("docs")
-    def validate_data_out(cls, v):
-        if not validators.url(v):
-            raise BadRequest(
-                code="NotValidUrl",
-                message="Input is not a valid URL",
-            )
-        return v
-
 class Task(TaskBase):
     uuid: str
     name: str

--- a/projects/schemas/task.py
+++ b/projects/schemas/task.py
@@ -119,7 +119,35 @@ class TaskUpdate(TaskBase):
     def validate_description(cls, v):
         generic_validators.raise_if_exceeded(MAX_CHARS_ALLOWED_DESCRIPTION, v)
         return v
+    @validator("tags")
+    def validate_tags(cls, v):
+        if len(v) > MAX_TAGS_ALLOWED:
+            raise BadRequest(
+                code="ExceededTagAmount",
+                message="Tag quantity exceeded maximum allowed",
+            )
 
+        for tag in v:
+            generic_validators.raise_if_exceeded(MAX_CHARS_ALLOWED, tag)
+            generic_validators.raise_if_forbidden_character(
+                FORBIDDEN_CHARACTERS_REGEX, tag
+            )
+
+        return v
+
+    @validator("data_in", "data_out", each_item=True)
+    def validate_data_in_out(cls, v):
+        generic_validators.raise_if_exceeded(MAX_CHARS_ALLOWED_DATA, v)
+        return v
+
+    @validator("docs")
+    def validate_data_out(cls, v):
+        if not validators.url(v):
+            raise BadRequest(
+                code="NotValidUrl",
+                message="Input is not a valid URL",
+            )
+        return v
 
 class Task(TaskBase):
     uuid: str

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1068,3 +1068,124 @@ class TestTasks(unittest.TestCase):
         )
 
         self.assertEqual(rv.status_code, 200)
+
+
+
+    def test_update_task_exceeded_amount_characters_in_dataIn(self):
+        """
+        Should return http status 400 when task data_in has a exceeded amount of char .
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "dataIn": DESCRIPTION
+            },
+        )
+        result = rv.json()
+        expected = {
+            "code": "ExceededCharQuantity",
+            "message": "Exceeded maximum character quantity allowed",
+        }
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_update_task_exceeded_amount_characters_in_dataOut(self):
+        """
+        Should return http status 400 when task data_out has a exceeded amount of char .
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "dataIn": DESCRIPTION
+            },
+        )
+        result = rv.json()
+        expected = {
+            "code": "ExceededCharQuantity",
+            "message": "Exceeded maximum character quantity allowed",
+        }
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_update_task_exceeded_amount_tags(self):
+        """
+        Should return http status 400 when task has more tags than maximum allowed.
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={"tags": ["tag1", "tag2", "tag3", "tag4", "tag5", "tag6"]}
+        )
+        result = rv.json()
+        expected = {
+            "code": "ExceededTagAmount",
+            "message": "Tag quantity exceeded maximum allowed",
+        }
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_update_task_tags_with_forbidden_char(self):
+        """
+        Should return http status 400 when task tag has any forbidden char.
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "tags": [
+                    "tag1",
+                    "tag2",
+                    "tag3",
+                    "tag4",
+                    "tag@",
+                ]
+            },
+        )
+        result = rv.json()
+        expected = {
+            "code": "NotAllowedChar",
+            "message": "Character not Allowed",
+        }
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_update_task_exceeded_amount_characters_in_tag(self):
+        """
+        Should return http status 400 when task tag has a exceeded amount of char .
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "tags": [
+                    "tag1",
+                    "tag2",
+                    "tag3",
+                    "tag4",
+                    "LoremipsumdolorsitametconsecteturadipiscingelitInteerelitexauc",
+                ]
+            },
+        )
+        result = rv.json()
+        expected = {
+            "code": "ExceededCharQuantity",
+            "message": "Exceeded maximum character quantity allowed",
+        }
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_update_task_docs_not_invalid_url(self):
+        """
+        Should return http status 400 when task doc is not a valid url .
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={"docs": "notAValidUrl"},
+        )
+        result = rv.json()
+        expected = {"code": "NotValidUrl", "message": "Input is not a valid URL"}
+        self.assertEqual(result, expected)
+        self.assertEqual(rv.status_code, 400)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -179,7 +179,7 @@ class TestTasks(unittest.TestCase):
         """
         for char in util.FORBIDDEN_CHARACTERS_LIST:
             rv = TEST_CLIENT.post(
-                "/tasks",
+                TASK_ROUTE,
                 json={"name": char},
             )
             result = rv.json()
@@ -195,7 +195,7 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task name has a exceeded amount of char .
         """
         rv = TEST_CLIENT.post(
-            "/tasks",
+            TASK_ROUTE,
             json={
                 "name": "LoremipsumdolorsitametconsecteturadipiscingelitInteerelitexauc"
             },
@@ -213,7 +213,7 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task description has a exceeded amount of char .
         """
         rv = TEST_CLIENT.post(
-            "/tasks",
+            TASK_ROUTE,
             json={
                 "description": DESCRIPTION
             },
@@ -231,7 +231,7 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task data_in has a exceeded amount of char .
         """
         rv = TEST_CLIENT.post(
-            "/tasks",
+            TASK_ROUTE,
             json={
                 "dataIn": DESCRIPTION
             },
@@ -249,7 +249,7 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task data_out has a exceeded amount of char .
         """
         rv = TEST_CLIENT.post(
-            "/tasks",
+            TASK_ROUTE,
             json={
                 "dataIn": DESCRIPTION
             },
@@ -267,7 +267,8 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task has more tags than maximum allowed.
         """
         rv = TEST_CLIENT.post(
-            "/tasks", json={"tags": ["tag1", "tag2", "tag3", "tag4", "tag5", "tag6"]}
+            TASK_ROUTE,
+            json={"tags": ["tag1", "tag2", "tag3", "tag4", "tag5", "tag6"]}
         )
         result = rv.json()
         expected = {
@@ -282,7 +283,7 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task tag has any forbidden char.
         """
         rv = TEST_CLIENT.post(
-            "/tasks",
+            TASK_ROUTE,
             json={
                 "tags": [
                     "tag1",
@@ -306,7 +307,7 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task tag has a exceeded amount of char .
         """
         rv = TEST_CLIENT.post(
-            "/tasks",
+            TASK_ROUTE,
             json={
                 "tags": [
                     "tag1",
@@ -330,7 +331,7 @@ class TestTasks(unittest.TestCase):
         Should return http status 400 when task doc is not a valid url .
         """
         rv = TEST_CLIENT.post(
-            "/tasks",
+            TASK_ROUTE,
             json={"docs": "notAValidUrl"},
         )
         result = rv.json()
@@ -1068,8 +1069,6 @@ class TestTasks(unittest.TestCase):
         )
 
         self.assertEqual(rv.status_code, 200)
-
-
 
     def test_update_task_exceeded_amount_characters_in_dataIn(self):
         """

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1089,6 +1089,30 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
 
+    @mock.patch(
+        "kubernetes.client.CoreV1Api",
+        return_value=util.MOCK_CORE_V1_API,
+    )
+    @mock.patch(
+        "kubernetes.client.CustomObjectsApi",
+        return_value=util.MOCK_CUSTOM_OBJECTS_API,
+    )
+    @mock.patch(
+        "kubernetes.config.load_kube_config",
+    )
+    def test_update_task_dataIn_success(self, mock_api, mock_custom_objects_api, mock_kube_config):
+        """
+        Should return http status 200.
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "dataIn": "description"
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+
     def test_update_task_exceeded_amount_characters_in_dataOut(self):
         """
         Should return http status 400 when task data_out has a exceeded amount of char .
@@ -1107,6 +1131,30 @@ class TestTasks(unittest.TestCase):
         }
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
+
+    @mock.patch(
+        "kubernetes.client.CoreV1Api",
+        return_value=util.MOCK_CORE_V1_API,
+    )
+    @mock.patch(
+        "kubernetes.client.CustomObjectsApi",
+        return_value=util.MOCK_CUSTOM_OBJECTS_API,
+    )
+    @mock.patch(
+        "kubernetes.config.load_kube_config",
+    )
+    def test_update_task_dataOut_success(self, mock_api, mock_custom_objects_api, mock_kube_config):
+        """
+        Should return http status 200.
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "dataOut": "description"
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
 
     def test_update_task_exceeded_amount_tags(self):
         """
@@ -1175,6 +1223,35 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
 
+    @mock.patch(
+        "kubernetes.client.CoreV1Api",
+        return_value=util.MOCK_CORE_V1_API,
+    )
+    @mock.patch(
+        "kubernetes.client.CustomObjectsApi",
+        return_value=util.MOCK_CUSTOM_OBJECTS_API,
+    )
+    @mock.patch(
+        "kubernetes.config.load_kube_config",
+    )
+    def test_update_task_tag(self, mock_api, mock_custom_objects_api, mock_kube_config):
+        """
+        Should return http status 400 when task tag has a exceeded amount of char .
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={
+                "tags": [
+                    "tag1",
+                    "tag2",
+                    "tag3",
+                    "tag4",
+                ]
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+
     def test_update_task_docs_not_invalid_url(self):
         """
         Should return http status 400 when task doc is not a valid url .
@@ -1188,3 +1265,25 @@ class TestTasks(unittest.TestCase):
         expected = {"code": "NotValidUrl", "message": "Input is not a valid URL"}
         self.assertEqual(result, expected)
         self.assertEqual(rv.status_code, 400)
+
+    @mock.patch(
+        "kubernetes.client.CoreV1Api",
+        return_value=util.MOCK_CORE_V1_API,
+    )
+    @mock.patch(
+        "kubernetes.client.CustomObjectsApi",
+        return_value=util.MOCK_CUSTOM_OBJECTS_API,
+    )
+    @mock.patch(
+        "kubernetes.config.load_kube_config",
+    )
+    def test_update_task_docs(self, mock_api, mock_custom_objects_api, mock_kube_config):
+        """
+        Should return http status 200.
+        """
+        task_id = util.MOCK_UUID_5
+        rv = TEST_CLIENT.patch(
+            f"/tasks/{task_id}",
+            json={"docs": "https://www.google.com.br"},
+        )
+        self.assertEqual(rv.status_code, 200)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -83,7 +83,7 @@ class TestTasks(unittest.TestCase):
 
     def test_list_tasks_exceeded_amount_characters(self):
         """
-        Should return http status 400 when task name has a exceeded amount of char .
+        Should return http status 400 when task name has a exceeded amount of char.
         """
         rv = TEST_CLIENT.post(
             "/tasks/list-tasks",
@@ -192,7 +192,7 @@ class TestTasks(unittest.TestCase):
 
     def test_create_task_exceeded_amount_characters(self):
         """
-        Should return http status 400 when task name has a exceeded amount of char .
+        Should return http status 400 when task name has a exceeded amount of char.
         """
         rv = TEST_CLIENT.post(
             TASK_ROUTE,
@@ -210,7 +210,7 @@ class TestTasks(unittest.TestCase):
 
     def test_create_task_exceeded_amount_characters_in_description(self):
         """
-        Should return http status 400 when task description has a exceeded amount of char .
+        Should return http status 400 when task description has a exceeded amount of char.
         """
         rv = TEST_CLIENT.post(
             TASK_ROUTE,
@@ -228,7 +228,7 @@ class TestTasks(unittest.TestCase):
 
     def test_create_task_exceeded_amount_characters_in_dataIn(self):
         """
-        Should return http status 400 when task data_in has a exceeded amount of char .
+        Should return http status 400 when task data_in has a exceeded amount of char.
         """
         rv = TEST_CLIENT.post(
             TASK_ROUTE,
@@ -246,7 +246,7 @@ class TestTasks(unittest.TestCase):
 
     def test_create_task_exceeded_amount_characters_in_dataOut(self):
         """
-        Should return http status 400 when task data_out has a exceeded amount of char .
+        Should return http status 400 when task data_out has a exceeded amount of char.
         """
         rv = TEST_CLIENT.post(
             TASK_ROUTE,
@@ -304,7 +304,7 @@ class TestTasks(unittest.TestCase):
 
     def test_create_task_exceeded_amount_characters_in_tag(self):
         """
-        Should return http status 400 when task tag has a exceeded amount of char .
+        Should return http status 400 when task tag has a exceeded amount of char.
         """
         rv = TEST_CLIENT.post(
             TASK_ROUTE,
@@ -328,7 +328,7 @@ class TestTasks(unittest.TestCase):
 
     def test_create_task_docs_not_invalid_url(self):
         """
-        Should return http status 400 when task doc is not a valid url .
+        Should return http status 400 when task doc is not a valid url.
         """
         rv = TEST_CLIENT.post(
             TASK_ROUTE,
@@ -1072,7 +1072,7 @@ class TestTasks(unittest.TestCase):
 
     def test_update_task_exceeded_amount_characters_in_dataIn(self):
         """
-        Should return http status 400 when task data_in has a exceeded amount of char .
+        Should return http status 400 when task data_in has a exceeded amount of char.
         """
         task_id = util.MOCK_UUID_5
         rv = TEST_CLIENT.patch(
@@ -1115,7 +1115,7 @@ class TestTasks(unittest.TestCase):
 
     def test_update_task_exceeded_amount_characters_in_dataOut(self):
         """
-        Should return http status 400 when task data_out has a exceeded amount of char .
+        Should return http status 400 when task data_out has a exceeded amount of char.
         """
         task_id = util.MOCK_UUID_5
         rv = TEST_CLIENT.patch(
@@ -1200,7 +1200,7 @@ class TestTasks(unittest.TestCase):
 
     def test_update_task_exceeded_amount_characters_in_tag(self):
         """
-        Should return http status 400 when task tag has a exceeded amount of char .
+        Should return http status 400 when task tag has a exceeded amount of char.
         """
         task_id = util.MOCK_UUID_5
         rv = TEST_CLIENT.patch(
@@ -1236,7 +1236,7 @@ class TestTasks(unittest.TestCase):
     )
     def test_update_task_tag(self, mock_api, mock_custom_objects_api, mock_kube_config):
         """
-        Should return http status 400 when task tag has a exceeded amount of char .
+        Should return http status 200.
         """
         task_id = util.MOCK_UUID_5
         rv = TEST_CLIENT.patch(
@@ -1254,7 +1254,7 @@ class TestTasks(unittest.TestCase):
 
     def test_update_task_docs_not_invalid_url(self):
         """
-        Should return http status 400 when task doc is not a valid url .
+        Should return http status 400 when task doc is not a valid url.
         """
         task_id = util.MOCK_UUID_5
         rv = TEST_CLIENT.patch(


### PR DESCRIPTION
Add restriction to path /tasks/{task_id} on the fields:
- Tags, verificando os caracteres da tag e a quantidade das tags
- Docs, verificando que o campo só pode ser preenchido com urls
- data_in, verificando as quantidade de caracteres
- data_out, verificando as quantidade de caracteres